### PR TITLE
refactor: externalize API endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Strapi API endpoint
+# The frontend derives image and favicon URLs by replacing `/api` with `/uploads`.
+# Ensure your deployment serves uploaded assets from this same origin.
 NEXT_PUBLIC_STRAPI_URL=https://your-strapi-instance/api

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Strapi API endpoint
+NEXT_PUBLIC_STRAPI_URL=https://your-strapi-instance/api

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ bun install
 cp .env.example .env.local
 
 # Configure your Strapi API endpoint
-NEXT_PUBLIC_STRAPI_URL=https://st.zh3.de/api
+NEXT_PUBLIC_STRAPI_URL=https://your-strapi-instance/api
 ```
 
 ### 4. Development Server
@@ -224,7 +224,7 @@ bun run build
 out
 
 # Environment variables
-NEXT_PUBLIC_STRAPI_URL=https://st.zh3.de/api
+NEXT_PUBLIC_STRAPI_URL=https://your-strapi-instance/api
 ```
 
 ### Vercel

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ cp .env.example .env.local
 NEXT_PUBLIC_STRAPI_URL=https://your-strapi-instance/api
 ```
 
+The frontend builds image and favicon URLs by replacing the `/api` segment of
+`NEXT_PUBLIC_STRAPI_URL` with `/uploads`. Deployed environments must expose
+assets under this pattern (e.g. `https://your-strapi-instance/uploads/...`) so
+files continue to load correctly.
+
 ### 4. Development Server
 ```bash
 bun run dev
@@ -226,6 +231,10 @@ out
 # Environment variables
 NEXT_PUBLIC_STRAPI_URL=https://your-strapi-instance/api
 ```
+
+Uploads and favicons are resolved from the same origin by replacing `/api` with
+`/uploads` on `NEXT_PUBLIC_STRAPI_URL`. Ensure your hosting setup forwards
+`/uploads/*` to the Strapi server so these assets load in production.
 
 ### Vercel
 ```bash

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,13 @@
 /** @type {import('next').NextConfig} */
+const STRAPI_URL = process.env.NEXT_PUBLIC_STRAPI_URL || ''
+const STRAPI_HOSTNAME = STRAPI_URL ? new URL(STRAPI_URL).hostname : ''
+
 const nextConfig = {
   images: {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'st.zh3.de',
+        hostname: STRAPI_HOSTNAME,
         port: '',
         pathname: '/uploads/**',
       },

--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,21 @@
 /** @type {import('next').NextConfig} */
 const STRAPI_URL = process.env.NEXT_PUBLIC_STRAPI_URL || ''
-const STRAPI_HOSTNAME = STRAPI_URL ? new URL(STRAPI_URL).hostname : ''
+const STRAPI = STRAPI_URL ? new URL(STRAPI_URL) : null
+const STRAPI_HOSTNAME = STRAPI?.hostname || ''
+const STRAPI_PROTOCOL = STRAPI?.protocol.replace(':', '') || 'https'
+const STRAPI_BASE_PATH = STRAPI
+  ? STRAPI.pathname.replace(/\/api$/, '').replace(/\/$/, '')
+  : ''
+const STRAPI_UPLOADS_SEGMENT = 'uploads'
 
 const nextConfig = {
   images: {
     remotePatterns: [
       {
-        protocol: 'https',
+        protocol: STRAPI_PROTOCOL,
         hostname: STRAPI_HOSTNAME,
         port: '',
-        pathname: '/uploads/**',
+        pathname: `${STRAPI_BASE_PATH}/${STRAPI_UPLOADS_SEGMENT}/**`,
       },
     ],
     formats: ['image/webp', 'image/avif'],

--- a/scripts/explore-strapi-safe.js
+++ b/scripts/explore-strapi-safe.js
@@ -5,7 +5,7 @@
  * Explores the actual data structure safely
  */
 
-const baseUrl = 'https://st.zh3.de/api'
+const baseUrl = process.env.STRAPI_API_URL || process.env.NEXT_PUBLIC_STRAPI_URL || ''
 
 async function exploreStrapi() {
   console.log('🔍 Exploring Strapi Data Structure Safely...\n')

--- a/scripts/explore-strapi.js
+++ b/scripts/explore-strapi.js
@@ -5,7 +5,7 @@
  * Explores the actual data structure without assumptions
  */
 
-const baseUrl = 'https://st.zh3.de/api'
+const baseUrl = process.env.STRAPI_API_URL || process.env.NEXT_PUBLIC_STRAPI_URL || ''
 
 async function exploreStrapi() {
   console.log('🔍 Exploring Strapi Data Structure...\n')

--- a/scripts/find-zweitmeinung.js
+++ b/scripts/find-zweitmeinung.js
@@ -4,7 +4,7 @@
  * Find Zweitmeinung Site and Data
  */
 
-const baseUrl = 'https://st.zh3.de/api'
+const baseUrl = process.env.STRAPI_API_URL || process.env.NEXT_PUBLIC_STRAPI_URL || ''
 
 async function findZweitmeinung() {
   console.log('🔍 Looking for Zweitmeinung Site and Data...\n')

--- a/scripts/get-homepage-data.js
+++ b/scripts/get-homepage-data.js
@@ -4,7 +4,7 @@
  * Get Homepage Data for Zweitmeinung
  */
 
-const baseUrl = 'https://st.zh3.de/api'
+const baseUrl = process.env.STRAPI_API_URL || process.env.NEXT_PUBLIC_STRAPI_URL || ''
 
 async function getHomepageData() {
   console.log('🏠 Getting Homepage Data for Zweitmeinung...\n')

--- a/scripts/test-strapi-api.js
+++ b/scripts/test-strapi-api.js
@@ -5,7 +5,7 @@
  * Tests the connection to the Strapi backend and validates data structure
  */
 
-const baseUrl = 'https://st.zh3.de/api'
+const baseUrl = process.env.STRAPI_API_URL || process.env.NEXT_PUBLIC_STRAPI_URL || ''
 const possibleSiteIds = ['zweitmeinung-ng', 'zweitmeinu-ng', 'zweitmein-ng']
 
 async function testStrapiConnection() {

--- a/src/app/api/faq/autocomplete/route.ts
+++ b/src/app/api/faq/autocomplete/route.ts
@@ -1,436 +1,476 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from "next/server";
 
-const STRAPI_BASE_URL = 'https://st.zh3.de/api'
+const STRAPI_BASE_URL =
+  process.env.STRAPI_API_URL || process.env.NEXT_PUBLIC_STRAPI_URL || "";
 
 // Auto-complete suggestion types
 export interface AutoCompleteSuggestion {
-  id: string
-  text: string
-  type: 'faq' | 'medical-term' | 'popular-search' | 'category'
-  category?: string
-  description?: string
-  highlightedText?: string
-  score: number
+  id: string;
+  text: string;
+  type: "faq" | "medical-term" | "popular-search" | "category";
+  category?: string;
+  description?: string;
+  highlightedText?: string;
+  score: number;
 }
 
 export interface AutoCompleteResponse {
-  suggestions: AutoCompleteSuggestion[]
-  searchTerm: string
-  totalSuggestions: number
-  processingTime: number
+  suggestions: AutoCompleteSuggestion[];
+  searchTerm: string;
+  totalSuggestions: number;
+  processingTime: number;
 }
 
 // Medical dictionary with German healthcare terms and synonyms
 const MEDICAL_DICTIONARY = {
   // Zweitmeinung related
-  'zweitmeinung': {
-    synonyms: ['zweit meinung', 'zweite meinung', 'fachliche einschätzung', 'expert opinion'],
-    description: 'Unabhängige medizinische Bewertung einer Diagnose oder Behandlung'
+  zweitmeinung: {
+    synonyms: [
+      "zweit meinung",
+      "zweite meinung",
+      "fachliche einschätzung",
+      "expert opinion",
+    ],
+    description:
+      "Unabhängige medizinische Bewertung einer Diagnose oder Behandlung",
   },
-  'gutachten': {
-    synonyms: ['medizinisches gutachten', 'fachgutachten', 'expertise'],
-    description: 'Professionelle medizinische Einschätzung'
+  gutachten: {
+    synonyms: ["medizinisches gutachten", "fachgutachten", "expertise"],
+    description: "Professionelle medizinische Einschätzung",
   },
 
   // Kardiologie
-  'herz': {
-    synonyms: ['kardio', 'cardiac', 'herzkrankheit', 'herzerkrankung'],
-    description: 'Herzmedizin und Herz-Kreislauf-System'
+  herz: {
+    synonyms: ["kardio", "cardiac", "herzkrankheit", "herzerkrankung"],
+    description: "Herzmedizin und Herz-Kreislauf-System",
   },
-  'herzinfarkt': {
-    synonyms: ['myokardinfarkt', 'heart attack', 'herzanfall'],
-    description: 'Akuter Verschluss einer Herzkranzarterie'
+  herzinfarkt: {
+    synonyms: ["myokardinfarkt", "heart attack", "herzanfall"],
+    description: "Akuter Verschluss einer Herzkranzarterie",
   },
-  'bypass': {
-    synonyms: ['herzbypass', 'koronarer bypass', 'cabg'],
-    description: 'Operative Umleitung bei Gefäßverengungen'
+  bypass: {
+    synonyms: ["herzbypass", "koronarer bypass", "cabg"],
+    description: "Operative Umleitung bei Gefäßverengungen",
   },
-  'stent': {
-    synonyms: ['gefäßstütze', 'koronarstent', 'herzkatheter'],
-    description: 'Medizinische Gefäßstütze zur Offenhaltung'
+  stent: {
+    synonyms: ["gefäßstütze", "koronarstent", "herzkatheter"],
+    description: "Medizinische Gefäßstütze zur Offenhaltung",
   },
-  'schrittmacher': {
-    synonyms: ['herzschrittmacher', 'pacemaker', 'stimulator'],
-    description: 'Medizinisches Gerät zur Herzrhythmus-Regulierung'
+  schrittmacher: {
+    synonyms: ["herzschrittmacher", "pacemaker", "stimulator"],
+    description: "Medizinisches Gerät zur Herzrhythmus-Regulierung",
   },
 
   // Onkologie
-  'krebs': {
-    synonyms: ['karzinom', 'tumor', 'onkologie', 'malignität'],
-    description: 'Krebserkrankungen und Tumormedizin'
+  krebs: {
+    synonyms: ["karzinom", "tumor", "onkologie", "malignität"],
+    description: "Krebserkrankungen und Tumormedizin",
   },
-  'chemotherapie': {
-    synonyms: ['chemo', 'zytostatika', 'krebstherapie'],
-    description: 'Medikamentöse Krebsbehandlung'
+  chemotherapie: {
+    synonyms: ["chemo", "zytostatika", "krebstherapie"],
+    description: "Medikamentöse Krebsbehandlung",
   },
-  'bestrahlung': {
-    synonyms: ['strahlentherapie', 'radiotherapie', 'radiation'],
-    description: 'Strahlenbehandlung bei Krebs'
+  bestrahlung: {
+    synonyms: ["strahlentherapie", "radiotherapie", "radiation"],
+    description: "Strahlenbehandlung bei Krebs",
   },
-  'metastasen': {
-    synonyms: ['metastasierung', 'streuung', 'sekundärtumor'],
-    description: 'Tochtergeschwülste bei Krebserkrankungen'
+  metastasen: {
+    synonyms: ["metastasierung", "streuung", "sekundärtumor"],
+    description: "Tochtergeschwülste bei Krebserkrankungen",
   },
 
   // Intensivmedizin
-  'intensiv': {
-    synonyms: ['intensivstation', 'icu', 'intensivbehandlung'],
-    description: 'Intensivmedizinische Betreuung'
+  intensiv: {
+    synonyms: ["intensivstation", "icu", "intensivbehandlung"],
+    description: "Intensivmedizinische Betreuung",
   },
-  'beatmung': {
-    synonyms: ['ventilation', 'respirator', 'intubation'],
-    description: 'Künstliche Beatmung bei kritischen Patienten'
+  beatmung: {
+    synonyms: ["ventilation", "respirator", "intubation"],
+    description: "Künstliche Beatmung bei kritischen Patienten",
   },
-  'reanimation': {
-    synonyms: ['wiederbelebung', 'cpr', 'notfallmedizin'],
-    description: 'Lebensrettende Sofortmaßnahmen'
+  reanimation: {
+    synonyms: ["wiederbelebung", "cpr", "notfallmedizin"],
+    description: "Lebensrettende Sofortmaßnahmen",
   },
 
   // Gallenblase
-  'gallenblase': {
-    synonyms: ['galle', 'cholezyst', 'gallenstein'],
-    description: 'Gallenblase und Gallenwegerkrankungen'
+  gallenblase: {
+    synonyms: ["galle", "cholezyst", "gallenstein"],
+    description: "Gallenblase und Gallenwegerkrankungen",
   },
-  'gallenstein': {
-    synonyms: ['gallensteine', 'cholelithiasis', 'gallenkolik'],
-    description: 'Steinbildung in der Gallenblase'
+  gallenstein: {
+    synonyms: ["gallensteine", "cholelithiasis", "gallenkolik"],
+    description: "Steinbildung in der Gallenblase",
   },
-  'cholezystektomie': {
-    synonyms: ['gallenblasenentfernung', 'gallen op'],
-    description: 'Operative Entfernung der Gallenblase'
+  cholezystektomie: {
+    synonyms: ["gallenblasenentfernung", "gallen op"],
+    description: "Operative Entfernung der Gallenblase",
   },
 
   // Nephrologie
-  'niere': {
-    synonyms: ['nieren', 'nephro', 'nierenerkrankung'],
-    description: 'Nierenmedizin und Nierenerkrankungen'
+  niere: {
+    synonyms: ["nieren", "nephro", "nierenerkrankung"],
+    description: "Nierenmedizin und Nierenerkrankungen",
   },
-  'dialyse': {
-    synonyms: ['hämodialyse', 'peritonealdialyse', 'blutwäsche'],
-    description: 'Nierenersatztherapie bei Nierenversagen'
+  dialyse: {
+    synonyms: ["hämodialyse", "peritonealdialyse", "blutwäsche"],
+    description: "Nierenersatztherapie bei Nierenversagen",
   },
-  'niereninsuffizienz': {
-    synonyms: ['nierenversagen', 'nierenschwäche'],
-    description: 'Eingeschränkte Nierenfunktion'
+  niereninsuffizienz: {
+    synonyms: ["nierenversagen", "nierenschwäche"],
+    description: "Eingeschränkte Nierenfunktion",
   },
 
   // Schilddrüse
-  'schilddrüse': {
-    synonyms: ['thyroid', 'schild', 'schilddrüsenerkrankung'],
-    description: 'Schilddrüsenmedizin und Hormonstörungen'
+  schilddrüse: {
+    synonyms: ["thyroid", "schild", "schilddrüsenerkrankung"],
+    description: "Schilddrüsenmedizin und Hormonstörungen",
   },
-  'struma': {
-    synonyms: ['kropf', 'schilddrüsenvergrößerung'],
-    description: 'Vergrößerung der Schilddrüse'
+  struma: {
+    synonyms: ["kropf", "schilddrüsenvergrößerung"],
+    description: "Vergrößerung der Schilddrüse",
   },
-  'thyreoidektomie': {
-    synonyms: ['schilddrüsenentfernung', 'schilddrüsen op'],
-    description: 'Operative Entfernung der Schilddrüse'
+  thyreoidektomie: {
+    synonyms: ["schilddrüsenentfernung", "schilddrüsen op"],
+    description: "Operative Entfernung der Schilddrüse",
   },
 
   // Allgemeine Begriffe
-  'operation': {
-    synonyms: ['op', 'eingriff', 'chirurgie', 'surgery'],
-    description: 'Operative medizinische Behandlung'
+  operation: {
+    synonyms: ["op", "eingriff", "chirurgie", "surgery"],
+    description: "Operative medizinische Behandlung",
   },
-  'diagnose': {
-    synonyms: ['befund', 'krankheitsbild', 'diagnosis'],
-    description: 'Medizinische Krankheitsbestimmung'
+  diagnose: {
+    synonyms: ["befund", "krankheitsbild", "diagnosis"],
+    description: "Medizinische Krankheitsbestimmung",
   },
-  'therapie': {
-    synonyms: ['behandlung', 'therapy', 'treatment'],
-    description: 'Medizinische Behandlungsverfahren'
+  therapie: {
+    synonyms: ["behandlung", "therapy", "treatment"],
+    description: "Medizinische Behandlungsverfahren",
   },
-  'kosten': {
-    synonyms: ['preis', 'gebühren', 'erstattung', 'kostenübernahme'],
-    description: 'Kosten und Kostenübernahme für medizinische Leistungen'
-  }
-}
+  kosten: {
+    synonyms: ["preis", "gebühren", "erstattung", "kostenübernahme"],
+    description: "Kosten und Kostenübernahme für medizinische Leistungen",
+  },
+};
 
 // Popular searches (these would typically come from analytics)
 const POPULAR_SEARCHES = [
-  'Zweitmeinung Kosten',
-  'Operation notwendig',
-  'Krebs Behandlung',
-  'Herz Katheter',
-  'Gallenblase entfernen',
-  'Schilddrüse Operation',
-  'Dialyse Alternativen',
-  'Intensivmedizin Entscheidung',
-  'Chemotherapie sinnvoll',
-  'Bypass Operation',
-  'Stent oder Operation',
-  'Zweitmeinung Ablauf',
-  'Experten finden',
-  'Gutachten anfordern',
-  'Behandlung überprüfen'
-]
+  "Zweitmeinung Kosten",
+  "Operation notwendig",
+  "Krebs Behandlung",
+  "Herz Katheter",
+  "Gallenblase entfernen",
+  "Schilddrüse Operation",
+  "Dialyse Alternativen",
+  "Intensivmedizin Entscheidung",
+  "Chemotherapie sinnvoll",
+  "Bypass Operation",
+  "Stent oder Operation",
+  "Zweitmeinung Ablauf",
+  "Experten finden",
+  "Gutachten anfordern",
+  "Behandlung überprüfen",
+];
 
 // Rate limiting for auto-complete
-const autoCompleteRateLimit = new Map<string, { count: number; resetTime: number }>()
-const RATE_LIMIT_WINDOW = 10 * 1000 // 10 seconds
-const RATE_LIMIT_MAX_REQUESTS = 50 // 50 requests per 10 seconds
+const autoCompleteRateLimit = new Map<
+  string,
+  { count: number; resetTime: number }
+>();
+const RATE_LIMIT_WINDOW = 10 * 1000; // 10 seconds
+const RATE_LIMIT_MAX_REQUESTS = 50; // 50 requests per 10 seconds
 
 // Cache for auto-complete results
-const autoCompleteCache = new Map<string, { data: AutoCompleteResponse; timestamp: number }>()
-const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+const autoCompleteCache = new Map<
+  string,
+  { data: AutoCompleteResponse; timestamp: number }
+>();
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
 function checkAutoCompleteRateLimit(clientIP: string): boolean {
-  const now = Date.now()
-  const clientData = autoCompleteRateLimit.get(clientIP)
+  const now = Date.now();
+  const clientData = autoCompleteRateLimit.get(clientIP);
 
   if (!clientData) {
-    autoCompleteRateLimit.set(clientIP, { count: 1, resetTime: now + RATE_LIMIT_WINDOW })
-    return true
+    autoCompleteRateLimit.set(clientIP, {
+      count: 1,
+      resetTime: now + RATE_LIMIT_WINDOW,
+    });
+    return true;
   }
 
   if (now > clientData.resetTime) {
-    autoCompleteRateLimit.set(clientIP, { count: 1, resetTime: now + RATE_LIMIT_WINDOW })
-    return true
+    autoCompleteRateLimit.set(clientIP, {
+      count: 1,
+      resetTime: now + RATE_LIMIT_WINDOW,
+    });
+    return true;
   }
 
   if (clientData.count >= RATE_LIMIT_MAX_REQUESTS) {
-    return false
+    return false;
   }
 
-  clientData.count++
-  return true
+  clientData.count++;
+  return true;
 }
 
 function getClientIP(request: NextRequest): string {
-  const forwarded = request.headers.get('x-forwarded-for')
-  const real = request.headers.get('x-real-ip')
-  return forwarded?.split(',')[0] || real || 'unknown'
+  const forwarded = request.headers.get("x-forwarded-for");
+  const real = request.headers.get("x-real-ip");
+  return forwarded?.split(",")[0] || real || "unknown";
 }
 
 // Fuzzy string matching function
 function fuzzyMatch(searchTerm: string, target: string): number {
-  const search = searchTerm.toLowerCase()
-  const text = target.toLowerCase()
+  const search = searchTerm.toLowerCase();
+  const text = target.toLowerCase();
 
   // Exact match
   if (text.includes(search)) {
-    return 1.0
+    return 1.0;
   }
 
   // Word boundary match
-  const words = text.split(' ')
+  const words = text.split(" ");
   for (const word of words) {
     if (word.startsWith(search)) {
-      return 0.8
+      return 0.8;
     }
   }
 
   // Character similarity (simple Levenshtein-inspired)
-  let matches = 0
-  let searchIndex = 0
+  let matches = 0;
+  let searchIndex = 0;
 
   for (let i = 0; i < text.length && searchIndex < search.length; i++) {
     if (text[i] === search[searchIndex]) {
-      matches++
-      searchIndex++
+      matches++;
+      searchIndex++;
     }
   }
 
-  return matches / search.length * 0.6
+  return (matches / search.length) * 0.6;
 }
 
 // Highlight matching text
 function highlightText(text: string, searchTerm: string): string {
-  if (!searchTerm) return text
+  if (!searchTerm) return text;
 
-  const regex = new RegExp(`(${searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi')
-  return text.replace(regex, '<mark>$1</mark>')
+  const regex = new RegExp(
+    `(${searchTerm.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`,
+    "gi",
+  );
+  return text.replace(regex, "<mark>$1</mark>");
 }
 
 // Get suggestions from medical dictionary
-function getMedicalTermSuggestions(searchTerm: string, limit: number = 5): AutoCompleteSuggestion[] {
-  const suggestions: AutoCompleteSuggestion[] = []
-  const search = searchTerm.toLowerCase()
+function getMedicalTermSuggestions(
+  searchTerm: string,
+  limit: number = 5,
+): AutoCompleteSuggestion[] {
+  const suggestions: AutoCompleteSuggestion[] = [];
+  const search = searchTerm.toLowerCase();
 
   for (const [term, data] of Object.entries(MEDICAL_DICTIONARY)) {
     // Check main term
-    const mainScore = fuzzyMatch(search, term)
+    const mainScore = fuzzyMatch(search, term);
     if (mainScore > 0.3) {
       suggestions.push({
         id: `medical-${term}`,
         text: term,
-        type: 'medical-term',
+        type: "medical-term",
         description: data.description,
         highlightedText: highlightText(term, searchTerm),
-        score: mainScore
-      })
+        score: mainScore,
+      });
     }
 
     // Check synonyms
     for (const synonym of data.synonyms) {
-      const synonymScore = fuzzyMatch(search, synonym)
+      const synonymScore = fuzzyMatch(search, synonym);
       if (synonymScore > 0.3) {
         suggestions.push({
           id: `medical-synonym-${synonym}`,
           text: synonym,
-          type: 'medical-term',
+          type: "medical-term",
           description: `Synonym für: ${term}`,
           highlightedText: highlightText(synonym, searchTerm),
-          score: synonymScore * 0.9 // Slightly lower score for synonyms
-        })
+          score: synonymScore * 0.9, // Slightly lower score for synonyms
+        });
       }
     }
   }
 
-  return suggestions
-    .sort((a, b) => b.score - a.score)
-    .slice(0, limit)
+  return suggestions.sort((a, b) => b.score - a.score).slice(0, limit);
 }
 
 // Get suggestions from popular searches
-function getPopularSearchSuggestions(searchTerm: string, limit: number = 3): AutoCompleteSuggestion[] {
-  const suggestions: AutoCompleteSuggestion[] = []
-  const search = searchTerm.toLowerCase()
+function getPopularSearchSuggestions(
+  searchTerm: string,
+  limit: number = 3,
+): AutoCompleteSuggestion[] {
+  const suggestions: AutoCompleteSuggestion[] = [];
+  const search = searchTerm.toLowerCase();
 
   for (const popularSearch of POPULAR_SEARCHES) {
-    const score = fuzzyMatch(search, popularSearch)
+    const score = fuzzyMatch(search, popularSearch);
     if (score > 0.3) {
       suggestions.push({
         id: `popular-${popularSearch}`,
         text: popularSearch,
-        type: 'popular-search',
-        description: 'Beliebte Suche',
+        type: "popular-search",
+        description: "Beliebte Suche",
         highlightedText: highlightText(popularSearch, searchTerm),
-        score: score * 0.8 // Lower priority than medical terms
-      })
+        score: score * 0.8, // Lower priority than medical terms
+      });
     }
   }
 
-  return suggestions
-    .sort((a, b) => b.score - a.score)
-    .slice(0, limit)
+  return suggestions.sort((a, b) => b.score - a.score).slice(0, limit);
 }
 
 // Get suggestions from FAQ questions (simplified - in production would query Strapi)
-async function getFAQSuggestions(searchTerm: string, limit: number = 3): Promise<AutoCompleteSuggestion[]> {
+async function getFAQSuggestions(
+  searchTerm: string,
+  limit: number = 3,
+): Promise<AutoCompleteSuggestion[]> {
   try {
     // This would typically query Strapi for FAQ questions
     // For now, we'll use a simplified approach
-    const response = await fetch(`${STRAPI_BASE_URL}/faqs?filters[question][$containsi]=${encodeURIComponent(searchTerm)}&pagination[limit]=${limit}&populate=category`, {
-      headers: { 'Content-Type': 'application/json' },
-      cache: 'no-store'
-    })
+    const response = await fetch(
+      `${STRAPI_BASE_URL}/faqs?filters[question][$containsi]=${encodeURIComponent(searchTerm)}&pagination[limit]=${limit}&populate=category`,
+      {
+        headers: { "Content-Type": "application/json" },
+        cache: "no-store",
+      },
+    );
 
     if (!response.ok) {
-      return []
+      return [];
     }
 
-    const data = await response.json()
-    const faqs = data.data || []
+    const data = await response.json();
+    const faqs = data.data || [];
 
     return faqs.map((faq: any, index: number) => ({
       id: `faq-${faq.id}`,
       text: faq.question,
-      type: 'faq' as const,
-      category: faq.category?.name || 'Allgemein',
-      description: 'FAQ-Frage',
+      type: "faq" as const,
+      category: faq.category?.name || "Allgemein",
+      description: "FAQ-Frage",
       highlightedText: highlightText(faq.question, searchTerm),
-      score: 0.9 - (index * 0.1) // Decreasing score based on order
-    }))
+      score: 0.9 - index * 0.1, // Decreasing score based on order
+    }));
   } catch (error) {
-    console.error('Error fetching FAQ suggestions:', error)
-    return []
+    console.error("Error fetching FAQ suggestions:", error);
+    return [];
   }
 }
 
 // Main auto-complete endpoint
-export async function GET(request: NextRequest): Promise<NextResponse<AutoCompleteResponse>> {
-  const startTime = Date.now()
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<AutoCompleteResponse>> {
+  const startTime = Date.now();
 
   try {
     // Check rate limit
-    const clientIP = getClientIP(request)
+    const clientIP = getClientIP(request);
     if (!checkAutoCompleteRateLimit(clientIP)) {
       return NextResponse.json(
         {
           suggestions: [],
-          searchTerm: '',
+          searchTerm: "",
           totalSuggestions: 0,
-          processingTime: 0
+          processingTime: 0,
         },
-        { status: 429 }
-      )
+        { status: 429 },
+      );
     }
 
     // Get search parameters
-    const { searchParams } = new URL(request.url)
-    const query = searchParams.get('q')?.trim()
-    const maxResults = parseInt(searchParams.get('limit') || '10', 10)
+    const { searchParams } = new URL(request.url);
+    const query = searchParams.get("q")?.trim();
+    const maxResults = parseInt(searchParams.get("limit") || "10", 10);
 
     if (!query || query.length < 2) {
       return NextResponse.json({
         suggestions: [],
-        searchTerm: query || '',
+        searchTerm: query || "",
         totalSuggestions: 0,
-        processingTime: Date.now() - startTime
-      })
+        processingTime: Date.now() - startTime,
+      });
     }
 
     // Check cache
-    const cacheKey = `${query.toLowerCase()}-${maxResults}`
-    const cached = autoCompleteCache.get(cacheKey)
+    const cacheKey = `${query.toLowerCase()}-${maxResults}`;
+    const cached = autoCompleteCache.get(cacheKey);
     if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
       return NextResponse.json({
         ...cached.data,
-        processingTime: Date.now() - startTime
-      })
+        processingTime: Date.now() - startTime,
+      });
     }
 
     // Get suggestions from different sources
-    const [medicalSuggestions, popularSuggestions, faqSuggestions] = await Promise.all([
-      getMedicalTermSuggestions(query, Math.ceil(maxResults * 0.5)),
-      getPopularSearchSuggestions(query, Math.ceil(maxResults * 0.3)),
-      getFAQSuggestions(query, Math.ceil(maxResults * 0.2))
-    ])
+    const [medicalSuggestions, popularSuggestions, faqSuggestions] =
+      await Promise.all([
+        getMedicalTermSuggestions(query, Math.ceil(maxResults * 0.5)),
+        getPopularSearchSuggestions(query, Math.ceil(maxResults * 0.3)),
+        getFAQSuggestions(query, Math.ceil(maxResults * 0.2)),
+      ]);
 
     // Combine and sort all suggestions
     const allSuggestions = [
       ...medicalSuggestions,
       ...popularSuggestions,
-      ...faqSuggestions
-    ]
+      ...faqSuggestions,
+    ];
 
     // Remove duplicates and sort by score
     const uniqueSuggestions = allSuggestions
-      .filter((suggestion, index, array) =>
-        array.findIndex(s => s.text.toLowerCase() === suggestion.text.toLowerCase()) === index
+      .filter(
+        (suggestion, index, array) =>
+          array.findIndex(
+            (s) => s.text.toLowerCase() === suggestion.text.toLowerCase(),
+          ) === index,
       )
       .sort((a, b) => b.score - a.score)
-      .slice(0, maxResults)
+      .slice(0, maxResults);
 
     const response: AutoCompleteResponse = {
       suggestions: uniqueSuggestions,
       searchTerm: query,
       totalSuggestions: uniqueSuggestions.length,
-      processingTime: Date.now() - startTime
-    }
+      processingTime: Date.now() - startTime,
+    };
 
     // Cache the result
     autoCompleteCache.set(cacheKey, {
       data: response,
-      timestamp: Date.now()
-    })
+      timestamp: Date.now(),
+    });
 
     // Log for analytics
-    console.log(`🔍 Auto-complete: "${query}" -> ${uniqueSuggestions.length} suggestions (${response.processingTime}ms)`)
+    console.log(
+      `🔍 Auto-complete: "${query}" -> ${uniqueSuggestions.length} suggestions (${response.processingTime}ms)`,
+    );
 
-    return NextResponse.json(response)
-
+    return NextResponse.json(response);
   } catch (error) {
-    console.error('Error in auto-complete API:', error)
+    console.error("Error in auto-complete API:", error);
 
-    return NextResponse.json({
-      suggestions: [],
-      searchTerm: '',
-      totalSuggestions: 0,
-      processingTime: Date.now() - startTime
-    }, { status: 500 })
+    return NextResponse.json(
+      {
+        suggestions: [],
+        searchTerm: "",
+        totalSuggestions: 0,
+        processingTime: Date.now() - startTime,
+      },
+      { status: 500 },
+    );
   }
 }
 
@@ -439,9 +479,9 @@ export async function OPTIONS(): Promise<NextResponse> {
   return new NextResponse(null, {
     status: 200,
     headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
     },
-  })
+  });
 }

--- a/src/app/api/faq/vote/route.ts
+++ b/src/app/api/faq/vote/route.ts
@@ -1,79 +1,86 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { headers } from 'next/headers'
+import { NextRequest, NextResponse } from "next/server";
+import { headers } from "next/headers";
 
-const STRAPI_BASE_URL = 'https://st.zh3.de/api'
+const STRAPI_BASE_URL =
+  process.env.STRAPI_API_URL || process.env.NEXT_PUBLIC_STRAPI_URL || "";
 
 // Rate limiting store (in production, use Redis or database)
-const rateLimitStore = new Map<string, { count: number; resetTime: number }>()
-const RATE_LIMIT_WINDOW = 60 * 1000 // 1 minute
-const RATE_LIMIT_MAX_REQUESTS = 10 // 10 votes per minute per IP
+const rateLimitStore = new Map<string, { count: number; resetTime: number }>();
+const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
+const RATE_LIMIT_MAX_REQUESTS = 10; // 10 votes per minute per IP
 
 // Vote request interface
 interface VoteRequest {
-  faqId: number
-  isHelpful: boolean
-  sessionId?: string
+  faqId: number;
+  isHelpful: boolean;
+  sessionId?: string;
 }
 
 // Vote response interface
 interface VoteResponse {
-  success: boolean
+  success: boolean;
   data?: {
-    faqId: number
-    helpfulCount: number
-    notHelpfulCount: number
-    userVote: boolean | null
-  }
-  error?: string
-  message?: string
+    faqId: number;
+    helpfulCount: number;
+    notHelpfulCount: number;
+    userVote: boolean | null;
+  };
+  error?: string;
+  message?: string;
 }
 
 // Rate limiting function
 function checkRateLimit(clientIP: string): boolean {
-  const now = Date.now()
-  const clientData = rateLimitStore.get(clientIP)
+  const now = Date.now();
+  const clientData = rateLimitStore.get(clientIP);
 
   if (!clientData) {
-    rateLimitStore.set(clientIP, { count: 1, resetTime: now + RATE_LIMIT_WINDOW })
-    return true
+    rateLimitStore.set(clientIP, {
+      count: 1,
+      resetTime: now + RATE_LIMIT_WINDOW,
+    });
+    return true;
   }
 
   if (now > clientData.resetTime) {
-    rateLimitStore.set(clientIP, { count: 1, resetTime: now + RATE_LIMIT_WINDOW })
-    return true
+    rateLimitStore.set(clientIP, {
+      count: 1,
+      resetTime: now + RATE_LIMIT_WINDOW,
+    });
+    return true;
   }
 
   if (clientData.count >= RATE_LIMIT_MAX_REQUESTS) {
-    return false
+    return false;
   }
 
-  clientData.count++
-  return true
+  clientData.count++;
+  return true;
 }
 
 // Get client IP address
 function getClientIP(request: NextRequest): string {
-  const forwarded = request.headers.get('x-forwarded-for')
-  const real = request.headers.get('x-real-ip')
-  const ip = forwarded?.split(',')[0] || real || 'unknown'
-  return ip
+  const forwarded = request.headers.get("x-forwarded-for");
+  const real = request.headers.get("x-real-ip");
+  const ip = forwarded?.split(",")[0] || real || "unknown";
+  return ip;
 }
 
 // Validate vote request
 function validateVoteRequest(data: any): { valid: boolean; error?: string } {
-  if (!data || typeof data !== 'object') {
-    return { valid: false, error: 'Invalid request body' }
+  if (!data || typeof data !== "object") {
+    return { valid: false, error: "Invalid request body" };
   }
 
-  if (typeof data.faqId !== 'number' || data.faqId <= 0) {
-    return { valid: false, error: 'Invalid FAQ ID' }
+  if (typeof data.faqId !== "number" || data.faqId <= 0) {
+    return { valid: false, error: "Invalid FAQ ID" };
   }
 
-  if (typeof data.isHelpful !== 'boolean') {
-    return { valid: false, error: 'Invalid vote value' }
+  if (typeof data.isHelpful !== "boolean") {
+    return { valid: false, error: "Invalid vote value" };
   }
 
-  return { valid: true }
+  return { valid: true };
 }
 
 // Fetch current FAQ data from Strapi
@@ -81,131 +88,145 @@ async function getCurrentFAQData(faqId: number): Promise<any> {
   try {
     const response = await fetch(`${STRAPI_BASE_URL}/faqs/${faqId}`, {
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
-      cache: 'no-store'
-    })
+      cache: "no-store",
+    });
 
     if (!response.ok) {
-      throw new Error(`Failed to fetch FAQ data: ${response.statusText}`)
+      throw new Error(`Failed to fetch FAQ data: ${response.statusText}`);
     }
 
-    const data = await response.json()
-    return data.data
+    const data = await response.json();
+    return data.data;
   } catch (error) {
-    console.error('Error fetching FAQ data:', error)
-    throw error
+    console.error("Error fetching FAQ data:", error);
+    throw error;
   }
 }
 
 // Update FAQ vote counts in Strapi
-async function updateFAQVotes(faqId: number, helpfulCount: number, notHelpfulCount: number): Promise<boolean> {
+async function updateFAQVotes(
+  faqId: number,
+  helpfulCount: number,
+  notHelpfulCount: number,
+): Promise<boolean> {
   try {
     const response = await fetch(`${STRAPI_BASE_URL}/faqs/${faqId}`, {
-      method: 'PUT',
+      method: "PUT",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({
         data: {
           helpfulCount,
-          notHelpfulCount
-        }
-      })
-    })
+          notHelpfulCount,
+        },
+      }),
+    });
 
     if (!response.ok) {
-      console.error(`Failed to update FAQ votes: ${response.statusText}`)
-      return false
+      console.error(`Failed to update FAQ votes: ${response.statusText}`);
+      return false;
     }
 
-    return true
+    return true;
   } catch (error) {
-    console.error('Error updating FAQ votes:', error)
-    return false
+    console.error("Error updating FAQ votes:", error);
+    return false;
   }
 }
 
 // Store user vote in localStorage (client-side handling)
 function generateSessionId(): string {
-  return `faq_session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+  return `faq_session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 }
 
 // POST: Submit a vote
-export async function POST(request: NextRequest): Promise<NextResponse<VoteResponse>> {
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<VoteResponse>> {
   try {
     // Get client IP for rate limiting
-    const clientIP = getClientIP(request)
+    const clientIP = getClientIP(request);
 
     // Check rate limit
     if (!checkRateLimit(clientIP)) {
       return NextResponse.json(
         {
           success: false,
-          error: 'Rate limit exceeded',
-          message: 'Zu viele Abstimmungen. Bitte versuchen Sie es in einer Minute erneut.'
+          error: "Rate limit exceeded",
+          message:
+            "Zu viele Abstimmungen. Bitte versuchen Sie es in einer Minute erneut.",
         },
-        { status: 429 }
-      )
+        { status: 429 },
+      );
     }
 
     // Parse request body
-    const body = await request.json()
+    const body = await request.json();
 
     // Validate request
-    const validation = validateVoteRequest(body)
+    const validation = validateVoteRequest(body);
     if (!validation.valid) {
       return NextResponse.json(
         {
           success: false,
           error: validation.error,
-          message: 'Ungültige Anfrage. Bitte versuchen Sie es erneut.'
+          message: "Ungültige Anfrage. Bitte versuchen Sie es erneut.",
         },
-        { status: 400 }
-      )
+        { status: 400 },
+      );
     }
 
-    const { faqId, isHelpful, sessionId }: VoteRequest = body
+    const { faqId, isHelpful, sessionId }: VoteRequest = body;
 
     // Get current FAQ data
-    const currentFAQ = await getCurrentFAQData(faqId)
+    const currentFAQ = await getCurrentFAQData(faqId);
     if (!currentFAQ) {
       return NextResponse.json(
         {
           success: false,
-          error: 'FAQ not found',
-          message: 'Die angegebene FAQ wurde nicht gefunden.'
+          error: "FAQ not found",
+          message: "Die angegebene FAQ wurde nicht gefunden.",
         },
-        { status: 404 }
-      )
+        { status: 404 },
+      );
     }
 
     // Calculate new vote counts
-    let newHelpfulCount = currentFAQ.helpfulCount || 0
-    let newNotHelpfulCount = currentFAQ.notHelpfulCount || 0
+    let newHelpfulCount = currentFAQ.helpfulCount || 0;
+    let newNotHelpfulCount = currentFAQ.notHelpfulCount || 0;
 
     if (isHelpful) {
-      newHelpfulCount++
+      newHelpfulCount++;
     } else {
-      newNotHelpfulCount++
+      newNotHelpfulCount++;
     }
 
     // Update votes in Strapi
-    const updateSuccess = await updateFAQVotes(faqId, newHelpfulCount, newNotHelpfulCount)
+    const updateSuccess = await updateFAQVotes(
+      faqId,
+      newHelpfulCount,
+      newNotHelpfulCount,
+    );
 
     if (!updateSuccess) {
       return NextResponse.json(
         {
           success: false,
-          error: 'Update failed',
-          message: 'Die Abstimmung konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.'
+          error: "Update failed",
+          message:
+            "Die Abstimmung konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
         },
-        { status: 500 }
-      )
+        { status: 500 },
+      );
     }
 
     // Log vote for analytics
-    console.log(`📊 FAQ Vote: FAQ ${faqId} - ${isHelpful ? 'Helpful' : 'Not Helpful'} - IP: ${clientIP}`)
+    console.log(
+      `📊 FAQ Vote: FAQ ${faqId} - ${isHelpful ? "Helpful" : "Not Helpful"} - IP: ${clientIP}`,
+    );
 
     // Return success response
     return NextResponse.json(
@@ -215,55 +236,49 @@ export async function POST(request: NextRequest): Promise<NextResponse<VoteRespo
           faqId,
           helpfulCount: newHelpfulCount,
           notHelpfulCount: newNotHelpfulCount,
-          userVote: isHelpful
+          userVote: isHelpful,
         },
-        message: 'Vielen Dank für Ihr Feedback!'
+        message: "Vielen Dank für Ihr Feedback!",
       },
-      { status: 200 }
-    )
-
+      { status: 200 },
+    );
   } catch (error) {
-    console.error('Error in FAQ vote API:', error)
+    console.error("Error in FAQ vote API:", error);
 
     return NextResponse.json(
       {
         success: false,
-        error: 'Internal server error',
-        message: 'Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.'
+        error: "Internal server error",
+        message:
+          "Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.",
       },
-      { status: 500 }
-    )
+      { status: 500 },
+    );
   }
 }
 
 // GET: Get vote statistics for a specific FAQ
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
-    const { searchParams } = new URL(request.url)
-    const faqIdParam = searchParams.get('faqId')
+    const { searchParams } = new URL(request.url);
+    const faqIdParam = searchParams.get("faqId");
 
     if (!faqIdParam) {
       return NextResponse.json(
-        { error: 'FAQ ID is required' },
-        { status: 400 }
-      )
+        { error: "FAQ ID is required" },
+        { status: 400 },
+      );
     }
 
-    const faqId = parseInt(faqIdParam, 10)
+    const faqId = parseInt(faqIdParam, 10);
     if (isNaN(faqId) || faqId <= 0) {
-      return NextResponse.json(
-        { error: 'Invalid FAQ ID' },
-        { status: 400 }
-      )
+      return NextResponse.json({ error: "Invalid FAQ ID" }, { status: 400 });
     }
 
     // Get current FAQ data
-    const currentFAQ = await getCurrentFAQData(faqId)
+    const currentFAQ = await getCurrentFAQData(faqId);
     if (!currentFAQ) {
-      return NextResponse.json(
-        { error: 'FAQ not found' },
-        { status: 404 }
-      )
+      return NextResponse.json({ error: "FAQ not found" }, { status: 404 });
     }
 
     return NextResponse.json(
@@ -272,19 +287,18 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         data: {
           faqId,
           helpfulCount: currentFAQ.helpfulCount || 0,
-          notHelpfulCount: currentFAQ.notHelpfulCount || 0
-        }
+          notHelpfulCount: currentFAQ.notHelpfulCount || 0,
+        },
       },
-      { status: 200 }
-    )
-
+      { status: 200 },
+    );
   } catch (error) {
-    console.error('Error getting FAQ vote stats:', error)
+    console.error("Error getting FAQ vote stats:", error);
 
     return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    )
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }
 
@@ -293,9 +307,9 @@ export async function OPTIONS(request: NextRequest): Promise<NextResponse> {
   return new NextResponse(null, {
     status: 200,
     headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
     },
-  })
+  });
 }

--- a/src/app/layout-original.tsx
+++ b/src/app/layout-original.tsx
@@ -1,23 +1,36 @@
-import type { Metadata } from 'next'
-import { Header } from '@/components/layout/Header'
-import { Footer } from '@/components/layout/Footer'
-import { getCachedSiteConfig } from '@/lib/strapi/site-config'
-import './globals.css'
+import type { Metadata } from "next";
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+
+const STRAPI_ORIGIN = (process.env.NEXT_PUBLIC_STRAPI_URL || "").replace(
+  /\/api$/,
+  "",
+);
+import { getCachedSiteConfig } from "@/lib/strapi/site-config";
+import "./globals.css";
 
 export async function generateMetadata(): Promise<Metadata> {
   try {
-    const siteConfig = await getCachedSiteConfig()
+    const siteConfig = await getCachedSiteConfig();
 
-    const siteName = siteConfig?.attributes.siteName || 'Zweitmeinung.ng'
-    const domain = siteConfig?.attributes.domain || 'zweitmein.ng'
+    const siteName = siteConfig?.attributes.siteName || "Zweitmeinung.ng";
+    const domain = siteConfig?.attributes.domain || "zweitmein.ng";
 
     return {
       title: {
         default: `${siteName} - Medizinische Zweitmeinung online`,
-        template: `%s | ${siteName}`
+        template: `%s | ${siteName}`,
       },
-      description: 'Erhalten Sie schnell und unkompliziert eine professionelle medizinische Zweitmeinung von Fachärzten. Vertrauen Sie auf unsere Expertise für Ihre Gesundheit.',
-      keywords: ['Zweitmeinung', 'Medizin', 'Gesundheit', 'Beratung', 'Facharzt', 'Online-Beratung'],
+      description:
+        "Erhalten Sie schnell und unkompliziert eine professionelle medizinische Zweitmeinung von Fachärzten. Vertrauen Sie auf unsere Expertise für Ihre Gesundheit.",
+      keywords: [
+        "Zweitmeinung",
+        "Medizin",
+        "Gesundheit",
+        "Beratung",
+        "Facharzt",
+        "Online-Beratung",
+      ],
       authors: [{ name: siteName }],
       creator: siteName,
       publisher: siteName,
@@ -28,18 +41,19 @@ export async function generateMetadata(): Promise<Metadata> {
       },
       metadataBase: new URL(`https://${domain}`),
       alternates: {
-        canonical: '/',
+        canonical: "/",
       },
       openGraph: {
         title: `${siteName} - Medizinische Zweitmeinung online`,
-        description: 'Erhalten Sie schnell und unkompliziert eine professionelle medizinische Zweitmeinung von Fachärzten.',
+        description:
+          "Erhalten Sie schnell und unkompliziert eine professionelle medizinische Zweitmeinung von Fachärzten.",
         url: `https://${domain}`,
         siteName: siteName,
-        locale: 'de_DE',
-        type: 'website',
+        locale: "de_DE",
+        type: "website",
         images: [
           {
-            url: '/og-image.jpg',
+            url: "/og-image.jpg",
             width: 1200,
             height: 630,
             alt: `${siteName} - Medizinische Zweitmeinung`,
@@ -47,10 +61,11 @@ export async function generateMetadata(): Promise<Metadata> {
         ],
       },
       twitter: {
-        card: 'summary_large_image',
+        card: "summary_large_image",
         title: `${siteName} - Medizinische Zweitmeinung online`,
-        description: 'Erhalten Sie schnell und unkompliziert eine professionelle medizinische Zweitmeinung von Fachärzten.',
-        images: ['/og-image.jpg'],
+        description:
+          "Erhalten Sie schnell und unkompliziert eine professionelle medizinische Zweitmeinung von Fachärzten.",
+        images: ["/og-image.jpg"],
       },
       robots: {
         index: true,
@@ -58,51 +73,59 @@ export async function generateMetadata(): Promise<Metadata> {
         googleBot: {
           index: true,
           follow: true,
-          'max-video-preview': -1,
-          'max-image-preview': 'large',
-          'max-snippet': -1,
+          "max-video-preview": -1,
+          "max-image-preview": "large",
+          "max-snippet": -1,
         },
       },
       verification: {
-        google: 'your-google-verification-code',
+        google: "your-google-verification-code",
         // other verification codes
       },
-    }
+    };
   } catch (error) {
-    console.error('💥 Error generating metadata:', error)
+    console.error("💥 Error generating metadata:", error);
 
     // Fallback metadata
     return {
-      title: 'Zweitmeinung.ng - Medizinische Zweitmeinung online',
-      description: 'Erhalten Sie schnell und unkompliziert eine professionelle medizinische Zweitmeinung von Fachärzten.',
-    }
+      title: "Zweitmeinung.ng - Medizinische Zweitmeinung online",
+      description:
+        "Erhalten Sie schnell und unkompliziert eine professionelle medizinische Zweitmeinung von Fachärzten.",
+    };
   }
 }
 
 export default async function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
-  let siteConfig = null
+  let siteConfig = null;
 
   try {
-    console.log('🏗️ Loading site configuration in layout...')
-    siteConfig = await getCachedSiteConfig()
-    console.log('✅ Site config loaded successfully:', siteConfig?.attributes?.siteName)
+    console.log("🏗️ Loading site configuration in layout...");
+    siteConfig = await getCachedSiteConfig();
+    console.log(
+      "✅ Site config loaded successfully:",
+      siteConfig?.attributes?.siteName,
+    );
   } catch (error) {
-    console.error('💥 Error loading site config in layout:', error)
+    console.error("💥 Error loading site config in layout:", error);
   }
 
   if (!siteConfig) {
-    console.log('⚠️ No site config available, using fallback layout')
+    console.log("⚠️ No site config available, using fallback layout");
 
     // Fallback Layout wenn Site Config nicht geladen werden kann
     return (
       <html lang="de">
         <head>
           <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="anonymous"
+          />
         </head>
         <body className="min-h-screen flex flex-col bg-healthcare-background">
           <div className="flex-grow flex items-center justify-center">
@@ -111,31 +134,39 @@ export default async function RootLayout({
                 Website wird geladen...
               </h1>
               <p className="text-healthcare-text-muted">
-                Bitte haben Sie einen Moment Geduld, während wir die Website-Konfiguration laden.
+                Bitte haben Sie einen Moment Geduld, während wir die
+                Website-Konfiguration laden.
               </p>
               <div className="mt-4 animate-spin w-8 h-8 border-4 border-healthcare-primary border-t-transparent rounded-full mx-auto"></div>
             </div>
           </div>
         </body>
       </html>
-    )
+    );
   }
 
   return (
     <html lang="de" className="scroll-smooth">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
 
         {/* Favicon */}
         {siteConfig.attributes.favicon?.data ? (
-          <link rel="icon" href={siteConfig.attributes.favicon.data.attributes.url} />
+          <link
+            rel="icon"
+            href={siteConfig.attributes.favicon.data.attributes.url}
+          />
         ) : (
           <link rel="icon" href="/favicon.ico" />
         )}
 
         {/* Preload critical resources */}
-        <link rel="dns-prefetch" href="https://st.zh3.de" />
+        <link rel="dns-prefetch" href={STRAPI_ORIGIN} />
 
         {/* SEO Meta Tags */}
         <meta name="theme-color" content="#004166" />
@@ -148,37 +179,39 @@ export default async function RootLayout({
             __html: JSON.stringify({
               "@context": "https://schema.org",
               "@type": "MedicalBusiness",
-              "name": siteConfig.attributes.siteName,
-              "url": `https://${siteConfig.attributes.domain}`,
-              "logo": siteConfig.attributes.logo?.data?.attributes.url,
-              "description": "Professionelle medizinische Zweitmeinung online",
-              "telephone": siteConfig.attributes.contact?.phone,
-              "email": siteConfig.attributes.contact?.email,
-              "address": siteConfig.attributes.contact?.address ? {
-                "@type": "PostalAddress",
-                "addressLocality": "Deutschland",
-                "addressRegion": "DE",
-                "streetAddress": siteConfig.attributes.contact.address
-              } : undefined,
-              "sameAs": [
+              name: siteConfig.attributes.siteName,
+              url: `https://${siteConfig.attributes.domain}`,
+              logo: siteConfig.attributes.logo?.data?.attributes.url,
+              description: "Professionelle medizinische Zweitmeinung online",
+              telephone: siteConfig.attributes.contact?.phone,
+              email: siteConfig.attributes.contact?.email,
+              address: siteConfig.attributes.contact?.address
+                ? {
+                    "@type": "PostalAddress",
+                    addressLocality: "Deutschland",
+                    addressRegion: "DE",
+                    streetAddress: siteConfig.attributes.contact.address,
+                  }
+                : undefined,
+              sameAs: [
                 siteConfig.attributes.socialMedia?.facebook,
                 siteConfig.attributes.socialMedia?.linkedin,
                 siteConfig.attributes.socialMedia?.instagram,
               ].filter(Boolean),
-              "hasOfferCatalog": {
+              hasOfferCatalog: {
                 "@type": "OfferCatalog",
-                "name": "Medizinische Leistungen",
-                "itemListElement": [
+                name: "Medizinische Leistungen",
+                itemListElement: [
                   {
                     "@type": "Offer",
-                    "itemOffered": {
+                    itemOffered: {
                       "@type": "MedicalProcedure",
-                      "name": "Medizinische Zweitmeinung"
-                    }
-                  }
-                ]
-              }
-            })
+                      name: "Medizinische Zweitmeinung",
+                    },
+                  },
+                ],
+              },
+            }),
           }}
         />
       </head>
@@ -200,17 +233,23 @@ export default async function RootLayout({
         <Footer siteConfig={siteConfig.attributes} />
 
         {/* Cookie Consent Banner */}
-        <div id="cookie-banner" className="fixed bottom-0 left-0 right-0 bg-healthcare-primary-dark text-white p-4 z-50 transform translate-y-full transition-transform duration-300">
+        <div
+          id="cookie-banner"
+          className="fixed bottom-0 left-0 right-0 bg-healthcare-primary-dark text-white p-4 z-50 transform translate-y-full transition-transform duration-300"
+        >
           <div className="container-custom flex flex-col md:flex-row items-center justify-between gap-4">
             <p className="text-sm">
-              Diese Website verwendet Cookies, um die bestmögliche Erfahrung zu gewährleisten.
+              Diese Website verwendet Cookies, um die bestmögliche Erfahrung zu
+              gewährleisten.
             </p>
             <div className="flex gap-2">
               <button
                 className="bg-healthcare-accent-green px-4 py-2 rounded text-sm hover:bg-healthcare-accent-hover transition-colors"
                 onClick={() => {
-                  document.getElementById('cookie-banner')?.classList.add('translate-y-full')
-                  localStorage.setItem('cookieConsent', 'accepted')
+                  document
+                    .getElementById("cookie-banner")
+                    ?.classList.add("translate-y-full");
+                  localStorage.setItem("cookieConsent", "accepted");
                 }}
               >
                 Akzeptieren
@@ -218,8 +257,10 @@ export default async function RootLayout({
               <button
                 className="bg-transparent border border-white px-4 py-2 rounded text-sm hover:bg-white hover:text-healthcare-primary transition-colors"
                 onClick={() => {
-                  document.getElementById('cookie-banner')?.classList.add('translate-y-full')
-                  localStorage.setItem('cookieConsent', 'declined')
+                  document
+                    .getElementById("cookie-banner")
+                    ?.classList.add("translate-y-full");
+                  localStorage.setItem("cookieConsent", "declined");
                 }}
               >
                 Ablehnen
@@ -241,10 +282,10 @@ export default async function RootLayout({
                   }, 2000);
                 }
               })();
-            `
+            `,
           }}
         />
       </body>
     </html>
-  )
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,10 +4,12 @@ import { getSiteConfig } from "@/lib/strapi/site-config";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 
-const STRAPI_ORIGIN = (process.env.NEXT_PUBLIC_STRAPI_URL || "").replace(
-  /\/api$/,
-  "",
-);
+const STRAPI_URL = process.env.NEXT_PUBLIC_STRAPI_URL || "";
+const STRAPI_ORIGIN = STRAPI_URL.replace(/\/api$/, "");
+const DEFAULT_FAVICON = new URL(
+  "uploads/favicon_af3459ec0b.ico",
+  STRAPI_ORIGIN,
+).toString();
 
 export async function generateMetadata(): Promise<Metadata> {
   let siteConfig = null;
@@ -19,6 +21,12 @@ export async function generateMetadata(): Promise<Metadata> {
   }
 
   const siteAttributes = siteConfig?.attributes;
+  const iconUrl = siteAttributes?.favicon?.data?.attributes?.url
+    ? new URL(
+        siteAttributes.favicon.data.attributes.url,
+        STRAPI_ORIGIN,
+      ).toString()
+    : DEFAULT_FAVICON;
 
   return {
     title: siteAttributes?.siteName
@@ -26,11 +34,7 @@ export async function generateMetadata(): Promise<Metadata> {
       : "Zweitmeinung.ng - Medizinische Zweitmeinung online",
     description:
       "Erhalten Sie schnell und unkompliziert eine professionelle medizinische Zweitmeinung von Fachärzten.",
-    icons: {
-      icon:
-        siteAttributes?.favicon?.data?.attributes?.url ||
-        `${STRAPI_ORIGIN}/uploads/favicon_af3459ec0b.ico`,
-    },
+    icons: { icon: iconUrl },
   };
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,116 +1,135 @@
-import type { Metadata } from 'next'
-import './globals.css'
-import { getSiteConfig } from '@/lib/strapi/site-config'
-import { Header } from '@/components/layout/Header'
-import { Footer } from '@/components/layout/Footer'
+import type { Metadata } from "next";
+import "./globals.css";
+import { getSiteConfig } from "@/lib/strapi/site-config";
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+
+const STRAPI_ORIGIN = (process.env.NEXT_PUBLIC_STRAPI_URL || "").replace(
+  /\/api$/,
+  "",
+);
 
 export async function generateMetadata(): Promise<Metadata> {
-  let siteConfig = null
+  let siteConfig = null;
 
   try {
-    siteConfig = await getSiteConfig()
+    siteConfig = await getSiteConfig();
   } catch (error) {
-    console.error('Error loading site config for metadata:', error)
+    console.error("Error loading site config for metadata:", error);
   }
 
-  const siteAttributes = siteConfig?.attributes
+  const siteAttributes = siteConfig?.attributes;
 
   return {
-    title: siteAttributes?.siteName ? `${siteAttributes.siteName} - Medizinische Zweitmeinung online` : 'Zweitmeinung.ng - Medizinische Zweitmeinung online',
-    description: 'Erhalten Sie schnell und unkompliziert eine professionelle medizinische Zweitmeinung von Fachärzten.',
+    title: siteAttributes?.siteName
+      ? `${siteAttributes.siteName} - Medizinische Zweitmeinung online`
+      : "Zweitmeinung.ng - Medizinische Zweitmeinung online",
+    description:
+      "Erhalten Sie schnell und unkompliziert eine professionelle medizinische Zweitmeinung von Fachärzten.",
     icons: {
-      icon: siteAttributes?.favicon?.data?.attributes?.url || 'https://st.zh3.de/uploads/favicon_af3459ec0b.ico',
+      icon:
+        siteAttributes?.favicon?.data?.attributes?.url ||
+        `${STRAPI_ORIGIN}/uploads/favicon_af3459ec0b.ico`,
     },
-  }
+  };
 }
 
 export default async function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   // Load site configuration from Strapi
-  let siteConfig = null
+  let siteConfig = null;
 
   try {
-    console.log('🔧 Loading site configuration for layout...')
-    siteConfig = await getSiteConfig()
-    console.log('✅ Site config loaded for layout:', siteConfig ? 'SUCCESS' : 'FAILED')
+    console.log("🔧 Loading site configuration for layout...");
+    siteConfig = await getSiteConfig();
+    console.log(
+      "✅ Site config loaded for layout:",
+      siteConfig ? "SUCCESS" : "FAILED",
+    );
   } catch (error) {
-    console.error('💥 Error loading site config in layout:', error)
+    console.error("💥 Error loading site config in layout:", error);
   }
 
   // Fallback site config if Strapi fails
   const fallbackSiteConfig = {
-    siteIdentifier: 'zweitmeinung-fallback',
-    domain: 'zweitmein.ng',
-    siteName: 'Zweitmeinung.ng',
-    brand: 'portal' as const,
+    siteIdentifier: "zweitmeinung-fallback",
+    domain: "zweitmein.ng",
+    siteName: "Zweitmeinung.ng",
+    brand: "portal" as const,
     navigation: {
       main: [
-        { id: 1, label: 'Home', href: '/' },
-        { id: 2, label: 'Zweitmeinung', href: '/zweitmeinung' },
-        { id: 3, label: 'Fachbereiche', href: '/fachbereiche' },
-        { id: 4, label: 'Kontakt', href: '/kontakt' },
+        { id: 1, label: "Home", href: "/" },
+        { id: 2, label: "Zweitmeinung", href: "/zweitmeinung" },
+        { id: 3, label: "Fachbereiche", href: "/fachbereiche" },
+        { id: 4, label: "Kontakt", href: "/kontakt" },
       ],
       footer: [
         {
           id: 1,
-          title: 'Services',
+          title: "Services",
           links: [
-            { id: 1, label: 'Medizinische Zweitmeinung', href: '/zweitmeinung' },
-            { id: 2, label: 'Online Beratung', href: '/beratung' },
-            { id: 3, label: 'Healthcare AI', href: '/ai-solutions' },
-          ]
+            {
+              id: 1,
+              label: "Medizinische Zweitmeinung",
+              href: "/zweitmeinung",
+            },
+            { id: 2, label: "Online Beratung", href: "/beratung" },
+            { id: 3, label: "Healthcare AI", href: "/ai-solutions" },
+          ],
         },
         {
           id: 2,
-          title: 'Rechtliches',
+          title: "Rechtliches",
           links: [
-            { id: 1, label: 'Impressum', href: '/impressum' },
-            { id: 2, label: 'Datenschutz', href: '/datenschutz' },
-            { id: 3, label: 'AGB', href: '/agb' },
-          ]
-        }
-      ]
+            { id: 1, label: "Impressum", href: "/impressum" },
+            { id: 2, label: "Datenschutz", href: "/datenschutz" },
+            { id: 3, label: "AGB", href: "/agb" },
+          ],
+        },
+      ],
     },
     contact: {
       id: 1,
-      email: 'info@zweitmein.ng',
-      phone: '+49 176 47870680',
-      emergencyPhone: '+49 176 47870680',
+      email: "info@zweitmein.ng",
+      phone: "+49 176 47870680",
+      emergencyPhone: "+49 176 47870680",
     },
     topBar: {
-      enabled: false
+      enabled: false,
     },
     ctaButton: {
-      label: 'Notfall-Zweitmeinung'
+      label: "Notfall-Zweitmeinung",
     },
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
-    publishedAt: new Date().toISOString()
-  }
+    publishedAt: new Date().toISOString(),
+  };
 
-  const siteAttributes = siteConfig?.attributes || fallbackSiteConfig
+  const siteAttributes = siteConfig?.attributes || fallbackSiteConfig;
 
   return (
     <html lang="de" className="scroll-smooth">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
         <meta name="theme-color" content="#004166" />
       </head>
       <body className="min-h-screen flex flex-col antialiased">
         {/* Dynamic Header from Strapi */}
         <Header siteConfig={siteAttributes} />
 
-        <main className="flex-grow">
-          {children}
-        </main>
+        <main className="flex-grow">{children}</main>
 
         {/* Dynamic Footer from Strapi */}
         <Footer siteConfig={siteAttributes} />
       </body>
     </html>
-  )
+  );
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,8 +1,13 @@
-'use client'
+"use client";
 
-import { useState } from 'react'
-import Link from 'next/link'
-import Image from 'next/image'
+import { useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+
+const STRAPI_ORIGIN = (process.env.NEXT_PUBLIC_STRAPI_URL || "").replace(
+  /\/api$/,
+  "",
+);
 import {
   Mail,
   Phone,
@@ -20,76 +25,92 @@ import {
   Star,
   Award,
   Badge,
-  Cookie
-} from 'lucide-react'
-import { cn } from '@/lib/utils'
-import type { SiteConfiguration } from '@/types/strapi'
+  Cookie,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SiteConfiguration } from "@/types/strapi";
 
 interface FooterProps {
-  siteConfig: SiteConfiguration['attributes']
+  siteConfig: SiteConfiguration["attributes"];
 }
 
 export function Footer({ siteConfig }: FooterProps) {
-  const [email, setEmail] = useState('')
-  const [isSubscribing, setIsSubscribing] = useState(false)
-  const [subscriptionStatus, setSubscriptionStatus] = useState<'idle' | 'success' | 'error'>('idle')
+  const [email, setEmail] = useState("");
+  const [isSubscribing, setIsSubscribing] = useState(false);
+  const [subscriptionStatus, setSubscriptionStatus] = useState<
+    "idle" | "success" | "error"
+  >("idle");
 
-  const currentYear = new Date().getFullYear()
+  const currentYear = new Date().getFullYear();
 
   const handleNewsletterSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!email || isSubscribing) return
+    e.preventDefault();
+    if (!email || isSubscribing) return;
 
-    setIsSubscribing(true)
+    setIsSubscribing(true);
 
     // Simulate API call
     setTimeout(() => {
-      setIsSubscribing(false)
-      setSubscriptionStatus('success')
-      setEmail('')
-      setTimeout(() => setSubscriptionStatus('idle'), 5000)
-    }, 1000)
-  }
+      setIsSubscribing(false);
+      setSubscriptionStatus("success");
+      setEmail("");
+      setTimeout(() => setSubscriptionStatus("idle"), 5000);
+    }, 1000);
+  };
 
   // Helper function to get icon component by name
   const getIcon = (iconName?: string) => {
     switch (iconName?.toLowerCase()) {
-      case 'heart': return <Heart className="w-4 h-4" />
-      case 'ribbon': return <Award className="w-4 h-4" />
-      case 'hospital': return <Shield className="w-4 h-4" />
-      case 'scalpel': return <Badge className="w-4 h-4" />
-      case 'x-ray': return <CheckCircle2 className="w-4 h-4" />
-      case 'user-doctor': return <Shield className="w-4 h-4" />
-      case 'cookie': return <Cookie className="w-4 h-4" />
-      case 'facebook': return <Facebook className="w-5 h-5" />
-      case 'linkedin': return <Linkedin className="w-5 h-5" />
-      case 'twitter': return <Twitter className="w-5 h-5" />
-      case 'youtube': return <Youtube className="w-5 h-5" />
-      default: return <ChevronRight className="w-4 h-4" />
+      case "heart":
+        return <Heart className="w-4 h-4" />;
+      case "ribbon":
+        return <Award className="w-4 h-4" />;
+      case "hospital":
+        return <Shield className="w-4 h-4" />;
+      case "scalpel":
+        return <Badge className="w-4 h-4" />;
+      case "x-ray":
+        return <CheckCircle2 className="w-4 h-4" />;
+      case "user-doctor":
+        return <Shield className="w-4 h-4" />;
+      case "cookie":
+        return <Cookie className="w-4 h-4" />;
+      case "facebook":
+        return <Facebook className="w-5 h-5" />;
+      case "linkedin":
+        return <Linkedin className="w-5 h-5" />;
+      case "twitter":
+        return <Twitter className="w-5 h-5" />;
+      case "youtube":
+        return <Youtube className="w-5 h-5" />;
+      default:
+        return <ChevronRight className="w-4 h-4" />;
     }
-  }
+  };
 
   // Use Strapi footer data or fallback
-  const footerData = siteConfig.footer
-  const footerStyle = footerData?.style || {}
+  const footerData = siteConfig.footer;
+  const footerStyle = footerData?.style || {};
 
   if (!footerData) {
     // Fallback to simple footer if no Strapi data
     return (
       <footer className="bg-healthcare-primary-dark text-white py-8">
         <div className="container-custom text-center">
-          <p>&copy; {currentYear} {siteConfig.siteName}. Alle Rechte vorbehalten.</p>
+          <p>
+            &copy; {currentYear} {siteConfig.siteName}. Alle Rechte vorbehalten.
+          </p>
         </div>
       </footer>
-    )
+    );
   }
 
   return (
     <footer
       className="text-white relative"
       style={{
-        backgroundColor: footerStyle.backgroundColor || '#004166',
-        color: footerStyle.textColor || '#ffffff'
+        backgroundColor: footerStyle.backgroundColor || "#004166",
+        color: footerStyle.textColor || "#ffffff",
       }}
     >
       {/* Emergency Banner */}
@@ -98,12 +119,14 @@ export function Footer({ siteConfig }: FooterProps) {
           className="w-full py-3 text-center"
           style={{
             backgroundColor: footerData.emergencyBanner.backgroundColor,
-            color: footerData.emergencyBanner.textColor
+            color: footerData.emergencyBanner.textColor,
           }}
         >
           <div className="container-custom">
             <div className="flex items-center justify-center gap-4">
-              <span className="font-medium">{footerData.emergencyBanner.text}</span>
+              <span className="font-medium">
+                {footerData.emergencyBanner.text}
+              </span>
               <a
                 href={`tel:${footerData.emergencyBanner.phone}`}
                 className="px-4 py-2 bg-white/20 rounded-lg font-semibold hover:bg-white/30 transition-colors"
@@ -119,27 +142,30 @@ export function Footer({ siteConfig }: FooterProps) {
       <div
         className="relative"
         style={{
-          paddingTop: footerStyle.padding?.top || '64px',
-          paddingBottom: footerStyle.padding?.bottom || '32px'
+          paddingTop: footerStyle.padding?.top || "64px",
+          paddingBottom: footerStyle.padding?.bottom || "32px",
         }}
       >
         <div className="container-custom">
-
           {/* Bottom Section (Brand + Description) */}
           {footerData.bottomSection && (
             <div className="mb-12 lg:mb-16">
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start">
-
                 {/* Logo & Description */}
                 <div className="lg:col-span-2">
                   {footerData.bottomSection.logo?.enabled && (
                     <div className="flex items-center gap-4 mb-6">
                       {siteConfig.logo?.data ? (
                         <Image
-                          src={siteConfig.logo.data.attributes.formats?.medium?.url ?
-                            `https://st.zh3.de${siteConfig.logo.data.attributes.formats.medium.url}` :
-                            siteConfig.logo.data.attributes.url}
-                          alt={siteConfig.logo.data.attributes.alternativeText || siteConfig.siteName}
+                          src={
+                            siteConfig.logo.data.attributes.formats?.medium?.url
+                              ? `${STRAPI_ORIGIN}${siteConfig.logo.data.attributes.formats.medium.url}`
+                              : siteConfig.logo.data.attributes.url
+                          }
+                          alt={
+                            siteConfig.logo.data.attributes.alternativeText ||
+                            siteConfig.siteName
+                          }
                           width={60}
                           height={60}
                           className="filter brightness-0 invert max-h-14 w-auto"
@@ -147,7 +173,7 @@ export function Footer({ siteConfig }: FooterProps) {
                       ) : (
                         <div className="w-14 h-14 bg-white rounded-lg flex items-center justify-center">
                           <span className="text-healthcare-primary font-bold text-xl">
-                            {siteConfig.siteName?.charAt(0) || 'Z'}
+                            {siteConfig.siteName?.charAt(0) || "Z"}
                           </span>
                         </div>
                       )}
@@ -155,7 +181,7 @@ export function Footer({ siteConfig }: FooterProps) {
                       {/* Site Name and Tagline */}
                       <div className="flex flex-col">
                         <div className="text-white font-bold text-2xl leading-tight">
-                          {siteConfig.siteName || 'zweitmeinung.ng'}
+                          {siteConfig.siteName || "zweitmeinung.ng"}
                         </div>
                         {siteConfig.tagline && (
                           <div className="text-gray-300 text-base leading-tight">
@@ -175,12 +201,17 @@ export function Footer({ siteConfig }: FooterProps) {
                   {/* Trust Badges */}
                   {footerData.bottomSection.trustBadges?.enabled && (
                     <div className="grid grid-cols-2 gap-3 mb-6">
-                      {footerData.bottomSection.trustBadges.items.map((badge, index) => (
-                        <div key={index} className="flex items-center gap-2 text-sm text-gray-300">
-                          <CheckCircle2 className="w-4 h-4 text-healthcare-accent-green flex-shrink-0" />
-                          <span>{badge}</span>
-                        </div>
-                      ))}
+                      {footerData.bottomSection.trustBadges.items.map(
+                        (badge, index) => (
+                          <div
+                            key={index}
+                            className="flex items-center gap-2 text-sm text-gray-300"
+                          >
+                            <CheckCircle2 className="w-4 h-4 text-healthcare-accent-green flex-shrink-0" />
+                            <span>{badge}</span>
+                          </div>
+                        ),
+                      )}
                     </div>
                   )}
                 </div>
@@ -192,12 +223,17 @@ export function Footer({ siteConfig }: FooterProps) {
                       Zertifizierungen
                     </h4>
                     <div className="flex flex-wrap gap-4 lg:justify-end">
-                      {footerData.bottomSection.certifications.items.map((cert, index) => (
-                        <div key={index} className="flex items-center gap-2 text-sm text-gray-300">
-                          <Shield className="w-4 h-4 text-healthcare-accent-green" />
-                          <span>{cert.name}</span>
-                        </div>
-                      ))}
+                      {footerData.bottomSection.certifications.items.map(
+                        (cert, index) => (
+                          <div
+                            key={index}
+                            className="flex items-center gap-2 text-sm text-gray-300"
+                          >
+                            <Shield className="w-4 h-4 text-healthcare-accent-green" />
+                            <span>{cert.name}</span>
+                          </div>
+                        ),
+                      )}
                     </div>
                   </div>
                 )}
@@ -209,7 +245,7 @@ export function Footer({ siteConfig }: FooterProps) {
           {footerData.columns && footerData.columns.length > 0 && (
             <div
               className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12"
-              style={{ columnGap: footerStyle.columnGap || '48px' }}
+              style={{ columnGap: footerStyle.columnGap || "48px" }}
             >
               {footerData.columns.map((column, index) => (
                 <div key={column.id || index}>
@@ -219,17 +255,24 @@ export function Footer({ siteConfig }: FooterProps) {
                   <ul className="space-y-3">
                     {column.links.map((link, linkIndex) => (
                       <li key={linkIndex}>
-                        {link.type === 'action' ? (
+                        {link.type === "action" ? (
                           <button
                             className={cn(
                               "flex items-center gap-2 transition-colors duration-300 hover:translate-x-1 text-left w-full",
-                              link.style === 'link-primary' ? 'text-healthcare-accent-green font-medium' : 'text-gray-300 hover:text-white'
+                              link.style === "link-primary"
+                                ? "text-healthcare-accent-green font-medium"
+                                : "text-gray-300 hover:text-white",
                             )}
-                            style={{ color: link.style === 'link-primary' ? footerStyle.linkColor : undefined }}
+                            style={{
+                              color:
+                                link.style === "link-primary"
+                                  ? footerStyle.linkColor
+                                  : undefined,
+                            }}
                             onClick={() => {
-                              if (link.action === 'openCookieSettings') {
+                              if (link.action === "openCookieSettings") {
                                 // Handle cookie settings
-                                console.log('Open cookie settings')
+                                console.log("Open cookie settings");
                               }
                             }}
                           >
@@ -239,8 +282,8 @@ export function Footer({ siteConfig }: FooterProps) {
                               <span
                                 className="ml-auto px-2 py-1 text-xs rounded-full font-medium"
                                 style={{
-                                  backgroundColor: link.badgeColor || '#B3AF09',
-                                  color: '#000'
+                                  backgroundColor: link.badgeColor || "#B3AF09",
+                                  color: "#000",
                                 }}
                               >
                                 {link.badge}
@@ -252,11 +295,26 @@ export function Footer({ siteConfig }: FooterProps) {
                             href={link.url}
                             className={cn(
                               "flex items-center gap-2 transition-colors duration-300 hover:translate-x-1",
-                              link.style === 'link-primary' ? 'text-healthcare-accent-green font-medium' : 'text-gray-300 hover:text-white'
+                              link.style === "link-primary"
+                                ? "text-healthcare-accent-green font-medium"
+                                : "text-gray-300 hover:text-white",
                             )}
-                            style={{ color: link.style === 'link-primary' ? footerStyle.linkColor : undefined }}
-                            target={link.type === 'external' || link.openInNewTab ? '_blank' : undefined}
-                            rel={link.type === 'external' || link.openInNewTab ? 'noopener noreferrer' : undefined}
+                            style={{
+                              color:
+                                link.style === "link-primary"
+                                  ? footerStyle.linkColor
+                                  : undefined,
+                            }}
+                            target={
+                              link.type === "external" || link.openInNewTab
+                                ? "_blank"
+                                : undefined
+                            }
+                            rel={
+                              link.type === "external" || link.openInNewTab
+                                ? "noopener noreferrer"
+                                : undefined
+                            }
                           >
                             {link.icon && getIcon(link.icon)}
                             <span>{link.label}</span>
@@ -264,8 +322,8 @@ export function Footer({ siteConfig }: FooterProps) {
                               <span
                                 className="ml-auto px-2 py-1 text-xs rounded-full font-medium"
                                 style={{
-                                  backgroundColor: link.badgeColor || '#B3AF09',
-                                  color: '#000'
+                                  backgroundColor: link.badgeColor || "#B3AF09",
+                                  color: "#000",
                                 }}
                               >
                                 {link.badge}
@@ -287,34 +345,42 @@ export function Footer({ siteConfig }: FooterProps) {
       {(footerData.socialMedia?.enabled || footerData.newsletter?.enabled) && (
         <div
           className="border-t py-8"
-          style={{ borderColor: footerStyle.borderColor || 'rgba(255, 255, 255, 0.1)' }}
+          style={{
+            borderColor: footerStyle.borderColor || "rgba(255, 255, 255, 0.1)",
+          }}
         >
           <div className="container-custom">
             <div className="flex flex-col lg:flex-row items-center justify-between gap-6">
-
               {/* Social Media */}
-              {footerData.socialMedia?.enabled && footerData.socialMedia.platforms.length > 0 && (
-                <div className="flex items-center gap-4">
-                  <span className="text-gray-400 text-sm">{footerData.socialMedia.title}:</span>
-                  <div className="flex items-center gap-3">
-                    {footerData.socialMedia.platforms.map((platform, index) => (
-                      <a
-                        key={index}
-                        href={platform.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="w-10 h-10 bg-healthcare-primary/50 rounded-full flex items-center justify-center hover:bg-healthcare-accent-green transition-colors duration-300"
-                        style={{
-                          '--hover-color': platform.color,
-                        } as React.CSSProperties}
-                        aria-label={platform.name}
-                      >
-                        {getIcon(platform.icon)}
-                      </a>
-                    ))}
+              {footerData.socialMedia?.enabled &&
+                footerData.socialMedia.platforms.length > 0 && (
+                  <div className="flex items-center gap-4">
+                    <span className="text-gray-400 text-sm">
+                      {footerData.socialMedia.title}:
+                    </span>
+                    <div className="flex items-center gap-3">
+                      {footerData.socialMedia.platforms.map(
+                        (platform, index) => (
+                          <a
+                            key={index}
+                            href={platform.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="w-10 h-10 bg-healthcare-primary/50 rounded-full flex items-center justify-center hover:bg-healthcare-accent-green transition-colors duration-300"
+                            style={
+                              {
+                                "--hover-color": platform.color,
+                              } as React.CSSProperties
+                            }
+                            aria-label={platform.name}
+                          >
+                            {getIcon(platform.icon)}
+                          </a>
+                        ),
+                      )}
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
 
               {/* Newsletter */}
               {footerData.newsletter?.enabled && (
@@ -343,16 +409,16 @@ export function Footer({ siteConfig }: FooterProps) {
                       disabled={isSubscribing || !email}
                       className="px-4 py-2 bg-healthcare-accent-green hover:bg-healthcare-accent-hover disabled:opacity-50 text-white rounded-r-md transition-colors duration-300"
                     >
-                      {isSubscribing ? '...' : footerData.newsletter.buttonText}
+                      {isSubscribing ? "..." : footerData.newsletter.buttonText}
                     </button>
                   </form>
 
-                  {subscriptionStatus === 'success' && (
+                  {subscriptionStatus === "success" && (
                     <div className="text-green-400 text-xs mt-1">
                       {footerData.newsletter.successMessage}
                     </div>
                   )}
-                  {subscriptionStatus === 'error' && (
+                  {subscriptionStatus === "error" && (
                     <div className="text-red-400 text-xs mt-1">
                       {footerData.newsletter.errorMessage}
                     </div>
@@ -367,12 +433,15 @@ export function Footer({ siteConfig }: FooterProps) {
       {/* Copyright */}
       <div
         className="border-t py-6"
-        style={{ borderColor: footerStyle.borderColor || 'rgba(255, 255, 255, 0.1)' }}
+        style={{
+          borderColor: footerStyle.borderColor || "rgba(255, 255, 255, 0.1)",
+        }}
       >
         <div className="container-custom">
           <div className="flex flex-col md:flex-row items-center justify-between gap-4 text-sm text-gray-400">
             <div>
-              {footerData.copyright?.text || `© ${currentYear} ${siteConfig.siteName}. Alle Rechte vorbehalten.`}
+              {footerData.copyright?.text ||
+                `© ${currentYear} ${siteConfig.siteName}. Alle Rechte vorbehalten.`}
             </div>
 
             <div className="flex items-center gap-4">
@@ -381,8 +450,10 @@ export function Footer({ siteConfig }: FooterProps) {
                   key={index}
                   href={link.url}
                   className="hover:text-white transition-colors"
-                  target={link.type === 'external' ? '_blank' : undefined}
-                  rel={link.type === 'external' ? 'noopener noreferrer' : undefined}
+                  target={link.type === "external" ? "_blank" : undefined}
+                  rel={
+                    link.type === "external" ? "noopener noreferrer" : undefined
+                  }
                 >
                   {link.label}
                 </Link>
@@ -395,5 +466,5 @@ export function Footer({ siteConfig }: FooterProps) {
         </div>
       </div>
     </footer>
-  )
+  );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,88 +1,110 @@
-'use client'
+"use client";
 
-import { useState, useEffect } from 'react'
-import Link from 'next/link'
-import Image from 'next/image'
-import { Menu, X, Phone, ChevronDown, Mail, Clock } from 'lucide-react'
-import { cn } from '@/lib/utils'
-import type { SiteConfiguration } from '@/types/strapi'
+import { useState, useEffect } from "react";
+
+const STRAPI_ORIGIN = (process.env.NEXT_PUBLIC_STRAPI_URL || "").replace(
+  /\/api$/,
+  "",
+);
+import Link from "next/link";
+import Image from "next/image";
+import { Menu, X, Phone, ChevronDown, Mail, Clock } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SiteConfiguration } from "@/types/strapi";
 
 interface HeaderProps {
-  siteConfig: SiteConfiguration['attributes']
+  siteConfig: SiteConfiguration["attributes"];
 }
 
 export function Header({ siteConfig }: HeaderProps) {
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-  const [activeDropdown, setActiveDropdown] = useState<number | null>(null)
-  const [logoError, setLogoError] = useState(false)
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [activeDropdown, setActiveDropdown] = useState<number | null>(null);
+  const [logoError, setLogoError] = useState(false);
 
   // Helper function to get formatted opening hours with status
   const getOpeningHoursInfo = () => {
-    if (!siteConfig.contact?.openingHours?.regular) return null
+    if (!siteConfig.contact?.openingHours?.regular) return null;
 
-    const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday']
-    const dayNamesGerman = ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag']
-    const now = new Date()
-    const currentDay = dayNames[now.getDay()]
-    const tomorrow = dayNames[(now.getDay() + 1) % 7]
+    const dayNames = [
+      "sunday",
+      "monday",
+      "tuesday",
+      "wednesday",
+      "thursday",
+      "friday",
+      "saturday",
+    ];
+    const dayNamesGerman = [
+      "Sonntag",
+      "Montag",
+      "Dienstag",
+      "Mittwoch",
+      "Donnerstag",
+      "Freitag",
+      "Samstag",
+    ];
+    const now = new Date();
+    const currentDay = dayNames[now.getDay()];
+    const tomorrow = dayNames[(now.getDay() + 1) % 7];
 
-    const todayHours = siteConfig.contact.openingHours.regular[currentDay]
-    const tomorrowHours = siteConfig.contact.openingHours.regular[tomorrow]
+    const todayHours = siteConfig.contact.openingHours.regular[currentDay];
+    const tomorrowHours = siteConfig.contact.openingHours.regular[tomorrow];
 
     // Check if currently open
     const isCurrentlyOpen = () => {
-      if (!todayHours || todayHours === 'geschlossen') return false
+      if (!todayHours || todayHours === "geschlossen") return false;
 
-      const currentTime = now.getHours() * 60 + now.getMinutes()
-      const timeRange = todayHours.split('-')
+      const currentTime = now.getHours() * 60 + now.getMinutes();
+      const timeRange = todayHours.split("-");
 
-      if (timeRange.length !== 2) return false
+      if (timeRange.length !== 2) return false;
 
-      const [openTime, closeTime] = timeRange
-      const [openHour, openMin] = openTime.split(':').map(Number)
-      const [closeHour, closeMin] = closeTime.split(':').map(Number)
+      const [openTime, closeTime] = timeRange;
+      const [openHour, openMin] = openTime.split(":").map(Number);
+      const [closeHour, closeMin] = closeTime.split(":").map(Number);
 
-      const openMinutes = openHour * 60 + (openMin || 0)
-      const closeMinutes = closeHour * 60 + (closeMin || 0)
+      const openMinutes = openHour * 60 + (openMin || 0);
+      const closeMinutes = closeHour * 60 + (closeMin || 0);
 
-      return currentTime >= openMinutes && currentTime < closeMinutes
-    }
+      return currentTime >= openMinutes && currentTime < closeMinutes;
+    };
 
     const formatHours = (hours: string) => {
-      if (hours === 'geschlossen') return 'geschlossen'
-      return hours.replace('-', ' - ')
-    }
+      if (hours === "geschlossen") return "geschlossen";
+      return hours.replace("-", " - ");
+    };
 
     return {
       isOpen: isCurrentlyOpen(),
       today: {
         day: dayNamesGerman[now.getDay()],
-        hours: formatHours(todayHours || 'geschlossen')
+        hours: formatHours(todayHours || "geschlossen"),
       },
       tomorrow: {
         day: dayNamesGerman[(now.getDay() + 1) % 7],
-        hours: formatHours(tomorrowHours || 'geschlossen')
-      }
-    }
-  }
+        hours: formatHours(tomorrowHours || "geschlossen"),
+      },
+    };
+  };
 
-  const openingInfo = getOpeningHoursInfo()
+  const openingInfo = getOpeningHoursInfo();
 
   useEffect(() => {
     // Close mobile menu when clicking outside
     const handleClickOutside = () => {
-      setIsMobileMenuOpen(false)
-      setActiveDropdown(null)
-    }
+      setIsMobileMenuOpen(false);
+      setActiveDropdown(null);
+    };
 
     if (isMobileMenuOpen) {
-      document.addEventListener('click', handleClickOutside)
-      return () => document.removeEventListener('click', handleClickOutside)
+      document.addEventListener("click", handleClickOutside);
+      return () => document.removeEventListener("click", handleClickOutside);
     }
-  }, [isMobileMenuOpen])
+  }, [isMobileMenuOpen]);
 
-  const emergencyPhone = siteConfig.contact?.emergencyHotline || siteConfig.contact?.phone
-  const emergencyText = siteConfig.ctaButton?.label || 'Notfall-Zweitmeinung'
+  const emergencyPhone =
+    siteConfig.contact?.emergencyHotline || siteConfig.contact?.phone;
+  const emergencyText = siteConfig.ctaButton?.label || "Notfall-Zweitmeinung";
 
   return (
     <>
@@ -91,24 +113,25 @@ export function Header({ siteConfig }: HeaderProps) {
         <div
           className="w-full py-3 px-4 text-sm z-50"
           style={{
-            backgroundColor: siteConfig.topBar.backgroundColor || '#004166',
-            color: siteConfig.topBar.textColor || '#ffffff'
+            backgroundColor: siteConfig.topBar.backgroundColor || "#004166",
+            color: siteConfig.topBar.textColor || "#ffffff",
           }}
           role="banner"
           aria-label="Kontakt-Informationen"
         >
           <div className="container-custom lg:px-[17px]">
             <div className="flex items-center justify-center md:justify-between">
-
               {/* Left Side - Contact Info */}
               <div className="flex items-center gap-6 flex-wrap justify-center md:justify-start">
                 {siteConfig.topBar.content?.map((item: any, index: number) => (
                   <div key={index}>
-                    {item.type === 'phone' && (
+                    {item.type === "phone" && (
                       <a
                         href={`tel:${item.content}`}
                         className="flex items-center gap-2 hover:text-healthcare-accent-green transition-colors duration-300 group"
-                        style={{ fontWeight: item.style === 'bold' ? '600' : 'normal' }}
+                        style={{
+                          fontWeight: item.style === "bold" ? "600" : "normal",
+                        }}
                         aria-label={`Telefon: ${item.content}`}
                       >
                         <Phone className="w-4 h-4 group-hover:scale-110 transition-transform" />
@@ -116,11 +139,13 @@ export function Header({ siteConfig }: HeaderProps) {
                         <span className="sm:hidden font-semibold">Hotline</span>
                       </a>
                     )}
-                    {item.type === 'email' && (
+                    {item.type === "email" && (
                       <a
                         href={`mailto:${item.content}`}
                         className="flex items-center gap-2 hover:text-healthcare-accent-green transition-colors duration-300 group"
-                        style={{ fontWeight: item.style === 'bold' ? '600' : 'normal' }}
+                        style={{
+                          fontWeight: item.style === "bold" ? "600" : "normal",
+                        }}
                         aria-label={`E-Mail: ${item.content}`}
                       >
                         <Mail className="w-4 h-4 group-hover:scale-110 transition-transform" />
@@ -128,18 +153,21 @@ export function Header({ siteConfig }: HeaderProps) {
                         <span className="md:hidden font-semibold">E-Mail</span>
                       </a>
                     )}
-                    {item.type === 'text' && (
+                    {item.type === "text" && (
                       <div className="flex items-center gap-2">
                         <Clock className="w-4 h-4" />
                         <span
                           className="font-medium"
-                          style={{ fontWeight: item.style === 'bold' ? '600' : 'normal' }}
+                          style={{
+                            fontWeight:
+                              item.style === "bold" ? "600" : "normal",
+                          }}
                         >
                           {item.content}
                         </span>
                       </div>
                     )}
-                    {item.type === 'separator' && (
+                    {item.type === "separator" && (
                       <span
                         className="text-white/40 mx-2 hidden lg:inline select-none"
                         aria-hidden="true"
@@ -159,17 +187,21 @@ export function Header({ siteConfig }: HeaderProps) {
                     <div className="flex items-center gap-3">
                       {/* Status Indicator */}
                       <div className="flex items-center gap-2">
-                        <div className={`w-2 h-2 rounded-full ${
-                          openingInfo.isOpen
-                            ? 'bg-green-400 animate-pulse'
-                            : 'bg-orange-400'
-                        }`}></div>
-                        <span className={`font-medium ${
-                          openingInfo.isOpen
-                            ? 'text-green-200'
-                            : 'text-orange-200'
-                        }`}>
-                          {openingInfo.isOpen ? 'Geöffnet' : 'Geschlossen'}
+                        <div
+                          className={`w-2 h-2 rounded-full ${
+                            openingInfo.isOpen
+                              ? "bg-green-400 animate-pulse"
+                              : "bg-orange-400"
+                          }`}
+                        ></div>
+                        <span
+                          className={`font-medium ${
+                            openingInfo.isOpen
+                              ? "text-green-200"
+                              : "text-orange-200"
+                          }`}
+                        >
+                          {openingInfo.isOpen ? "Geöffnet" : "Geschlossen"}
                         </span>
                       </div>
 
@@ -182,9 +214,11 @@ export function Header({ siteConfig }: HeaderProps) {
                       </div>
 
                       {/* Tomorrow's Hours (if different from today) */}
-                      {openingInfo.tomorrow.hours !== openingInfo.today.hours && (
+                      {openingInfo.tomorrow.hours !==
+                        openingInfo.today.hours && (
                         <span className="opacity-70 text-xs">
-                          {openingInfo.tomorrow.day}: {openingInfo.tomorrow.hours}
+                          {openingInfo.tomorrow.day}:{" "}
+                          {openingInfo.tomorrow.hours}
                         </span>
                       )}
                     </div>
@@ -201,14 +235,18 @@ export function Header({ siteConfig }: HeaderProps) {
                 <div className="text-white/60">|</div>
 
                 {/* Free Consultation Badge */}
-                <span className="text-white/90 font-medium">Kostenlose Beratung</span>
+                <span className="text-white/90 font-medium">
+                  Kostenlose Beratung
+                </span>
 
                 {/* Debug Info */}
-                {process.env.NODE_ENV === 'development' && (
+                {process.env.NODE_ENV === "development" && (
                   <>
                     <div className="text-white/60">|</div>
                     <span className="text-white/60 text-xs">
-                      {siteConfig.openingHours ? '✅ openingHours found' : '❌ openingHours missing'}
+                      {siteConfig.openingHours
+                        ? "✅ openingHours found"
+                        : "❌ openingHours missing"}
                     </span>
                   </>
                 )}
@@ -221,166 +259,87 @@ export function Header({ siteConfig }: HeaderProps) {
       {/* Main Header */}
       <header
         className="w-full transition-all duration-300 shadow-lg"
-        style={{ backgroundColor: '#004166' }}
+        style={{ backgroundColor: "#004166" }}
       >
         <div className="container-custom">
-        <nav className="flex items-center justify-between h-20">
-          {/* Logo */}
-          <Link href="/" className="flex items-center group">
-            <div className="flex items-center gap-3">
-              {siteConfig.logo?.data && !logoError ? (
-                <Image
-                  src={siteConfig.logo.data.attributes.formats?.medium?.url ?
-                    `https://st.zh3.de${siteConfig.logo.data.attributes.formats.medium.url}` :
-                    siteConfig.logo.data.attributes.url}
-                  alt={siteConfig.logo.data.attributes.alternativeText || `${siteConfig.siteName} Logo`}
-                  width={60}
-                  height={60}
-                  className="transition-transform duration-300 group-hover:scale-105 max-h-14 w-auto animate-pulse-slow"
-                  priority
-                  onError={() => {
-                    console.warn('Logo image failed to load, switching to text fallback')
-                    setLogoError(true)
-                  }}
-                  onLoad={() => {
-                    console.log('Logo image loaded successfully')
-                  }}
-                />
-              ) : (
-                <div className="w-14 h-14 bg-white rounded-lg flex items-center justify-center animate-pulse-slow">
-                  <span className="text-healthcare-primary font-bold text-xl">
-                    {siteConfig.siteName?.charAt(0) || 'Z'}
-                  </span>
-                </div>
-              )}
-
-              {/* Site Name and Tagline */}
-              <div className="flex flex-col">
-                <div className="text-white font-bold text-xl leading-tight group-hover:text-healthcare-accent-green transition-colors duration-300">
-                  {siteConfig.siteName || 'zweitmeinung.ng'}
-                </div>
-                {siteConfig.tagline && (
-                  <div className="text-white/80 text-sm leading-tight hidden sm:block">
-                    {siteConfig.tagline}
-                  </div>
-                )}
-                {process.env.NODE_ENV === 'development' && logoError && (
-                  <span className="text-xs text-red-400">(img failed)</span>
-                )}
-              </div>
-            </div>
-          </Link>
-
-          {/* Desktop Navigation */}
-          <div className="hidden lg:flex items-center space-x-8">
-            {siteConfig.navigation?.main?.map((item) => (
-              <div key={item.id} className="relative">
-                {item.children && item.children.length > 0 ? (
-                  // Dropdown menu
-                  <div
-                    className="relative"
-                    onMouseEnter={() => setActiveDropdown(item.id)}
-                    onMouseLeave={() => setActiveDropdown(null)}
-                  >
-                    <button
-                      className="flex items-center gap-1 font-medium transition-colors duration-300 relative group text-white hover:text-healthcare-accent-green"
-                    >
-                      {item.label}
-                      <ChevronDown className="w-4 h-4 transition-transform duration-300 group-hover:rotate-180" />
-                      <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-healthcare-primary-light transition-all duration-300 group-hover:w-full" />
-                    </button>
-
-                    {activeDropdown === item.id && (
-                      <div className="absolute top-full left-0 mt-2 w-48 bg-white rounded-lg shadow-xl border border-healthcare-border py-2 z-50">
-                        {item.children.map((child) => (
-                          <Link
-                            key={child.id}
-                            href={child.href}
-                            className="block px-4 py-2 text-healthcare-primary hover:bg-healthcare-background hover:text-healthcare-primary-light transition-colors"
-                          >
-                            {child.label}
-                          </Link>
-                        ))}
-                      </div>
-                    )}
-                  </div>
+          <nav className="flex items-center justify-between h-20">
+            {/* Logo */}
+            <Link href="/" className="flex items-center group">
+              <div className="flex items-center gap-3">
+                {siteConfig.logo?.data && !logoError ? (
+                  <Image
+                    src={
+                      siteConfig.logo.data.attributes.formats?.medium?.url
+                        ? `${STRAPI_ORIGIN}${siteConfig.logo.data.attributes.formats.medium.url}`
+                        : siteConfig.logo.data.attributes.url
+                    }
+                    alt={
+                      siteConfig.logo.data.attributes.alternativeText ||
+                      `${siteConfig.siteName} Logo`
+                    }
+                    width={60}
+                    height={60}
+                    className="transition-transform duration-300 group-hover:scale-105 max-h-14 w-auto animate-pulse-slow"
+                    priority
+                    onError={() => {
+                      console.warn(
+                        "Logo image failed to load, switching to text fallback",
+                      );
+                      setLogoError(true);
+                    }}
+                    onLoad={() => {
+                      console.log("Logo image loaded successfully");
+                    }}
+                  />
                 ) : (
-                  // Regular link
-                  <Link
-                    href={item.href}
-                    className="font-medium transition-colors duration-300 relative group text-white hover:text-healthcare-accent-green"
-                    target={item.isExternal ? '_blank' : undefined}
-                    rel={item.isExternal ? 'noopener noreferrer' : undefined}
-                  >
-                    {item.label}
-                    <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-healthcare-primary-light transition-all duration-300 group-hover:w-full" />
-                  </Link>
+                  <div className="w-14 h-14 bg-white rounded-lg flex items-center justify-center animate-pulse-slow">
+                    <span className="text-healthcare-primary font-bold text-xl">
+                      {siteConfig.siteName?.charAt(0) || "Z"}
+                    </span>
+                  </div>
                 )}
+
+                {/* Site Name and Tagline */}
+                <div className="flex flex-col">
+                  <div className="text-white font-bold text-xl leading-tight group-hover:text-healthcare-accent-green transition-colors duration-300">
+                    {siteConfig.siteName || "zweitmeinung.ng"}
+                  </div>
+                  {siteConfig.tagline && (
+                    <div className="text-white/80 text-sm leading-tight hidden sm:block">
+                      {siteConfig.tagline}
+                    </div>
+                  )}
+                  {process.env.NODE_ENV === "development" && logoError && (
+                    <span className="text-xs text-red-400">(img failed)</span>
+                  )}
+                </div>
               </div>
-            ))}
+            </Link>
 
-            {/* Emergency CTA Button */}
-            {emergencyPhone && (
-              <a
-                href={`tel:${emergencyPhone}`}
-                className={cn(
-                  "flex items-center gap-2 px-6 py-3 rounded-lg font-medium transition-all duration-300 hover:scale-105 animate-pulse-slow",
-                  "bg-healthcare-accent-green hover:bg-healthcare-accent-hover text-white",
-                  "relative before:absolute before:inset-0 before:rounded-lg before:bg-healthcare-accent-green before:animate-ping-slow before:opacity-20",
-                  "rounded-[10px]"
-                )}
-                style={{
-                  backgroundColor: siteConfig.ctaButton?.backgroundColor || undefined,
-                  color: siteConfig.ctaButton?.textColor || undefined
-                }}
-              >
-                <Phone className="w-4 h-4 animate-pulse-slow" />
-                {emergencyText}
-              </a>
-            )}
-          </div>
-
-          {/* Mobile Menu Button */}
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              setIsMobileMenuOpen(!isMobileMenuOpen)
-            }}
-            className="lg:hidden p-2 rounded-md transition-colors duration-300 text-white hover:bg-white/10"
-            aria-label="Toggle navigation menu"
-          >
-            {isMobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
-          </button>
-        </nav>
-      </div>
-
-      {/* Mobile Menu */}
-      {isMobileMenuOpen && (
-        <div className="lg:hidden bg-white border-t border-healthcare-border shadow-lg">
-          <div className="container-custom py-4">
-            <div className="space-y-1">
+            {/* Desktop Navigation */}
+            <div className="hidden lg:flex items-center space-x-8">
               {siteConfig.navigation?.main?.map((item) => (
-                <div key={item.id}>
+                <div key={item.id} className="relative">
                   {item.children && item.children.length > 0 ? (
-                    <div>
-                      <button
-                        onClick={() => setActiveDropdown(activeDropdown === item.id ? null : item.id)}
-                        className="flex items-center justify-between w-full py-3 text-healthcare-primary hover:text-healthcare-primary-light font-medium"
-                      >
+                    // Dropdown menu
+                    <div
+                      className="relative"
+                      onMouseEnter={() => setActiveDropdown(item.id)}
+                      onMouseLeave={() => setActiveDropdown(null)}
+                    >
+                      <button className="flex items-center gap-1 font-medium transition-colors duration-300 relative group text-white hover:text-healthcare-accent-green">
                         {item.label}
-                        <ChevronDown className={cn(
-                          "w-4 h-4 transition-transform duration-300",
-                          activeDropdown === item.id && "rotate-180"
-                        )} />
+                        <ChevronDown className="w-4 h-4 transition-transform duration-300 group-hover:rotate-180" />
+                        <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-healthcare-primary-light transition-all duration-300 group-hover:w-full" />
                       </button>
+
                       {activeDropdown === item.id && (
-                        <div className="pl-4 space-y-1">
+                        <div className="absolute top-full left-0 mt-2 w-48 bg-white rounded-lg shadow-xl border border-healthcare-border py-2 z-50">
                           {item.children.map((child) => (
                             <Link
                               key={child.id}
                               href={child.href}
-                              className="block py-2 text-healthcare-text-muted hover:text-healthcare-primary"
-                              onClick={() => setIsMobileMenuOpen(false)}
+                              className="block px-4 py-2 text-healthcare-primary hover:bg-healthcare-background hover:text-healthcare-primary-light transition-colors"
                             >
                               {child.label}
                             </Link>
@@ -389,45 +348,143 @@ export function Header({ siteConfig }: HeaderProps) {
                       )}
                     </div>
                   ) : (
+                    // Regular link
                     <Link
                       href={item.href}
-                      className="block py-3 text-healthcare-primary hover:text-healthcare-primary-light font-medium"
-                      onClick={() => setIsMobileMenuOpen(false)}
-                      target={item.isExternal ? '_blank' : undefined}
-                      rel={item.isExternal ? 'noopener noreferrer' : undefined}
+                      className="font-medium transition-colors duration-300 relative group text-white hover:text-healthcare-accent-green"
+                      target={item.isExternal ? "_blank" : undefined}
+                      rel={item.isExternal ? "noopener noreferrer" : undefined}
                     >
                       {item.label}
+                      <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-healthcare-primary-light transition-all duration-300 group-hover:w-full" />
                     </Link>
                   )}
                 </div>
               ))}
-            </div>
 
-            {/* Mobile Emergency Button */}
-            {emergencyPhone && (
-              <div className="mt-4 pt-4 border-t border-healthcare-border">
+              {/* Emergency CTA Button */}
+              {emergencyPhone && (
                 <a
                   href={`tel:${emergencyPhone}`}
                   className={cn(
-                    "flex items-center justify-center gap-2 w-full px-6 py-3 rounded-lg font-medium transition-all duration-300 animate-pulse-slow",
+                    "flex items-center gap-2 px-6 py-3 rounded-lg font-medium transition-all duration-300 hover:scale-105 animate-pulse-slow",
                     "bg-healthcare-accent-green hover:bg-healthcare-accent-hover text-white",
-                    "relative before:absolute before:inset-0 before:rounded-lg before:bg-healthcare-accent-green before:animate-ping-slow before:opacity-20"
+                    "relative before:absolute before:inset-0 before:rounded-lg before:bg-healthcare-accent-green before:animate-ping-slow before:opacity-20",
+                    "rounded-[10px]",
                   )}
                   style={{
-                    backgroundColor: siteConfig.ctaButton?.backgroundColor || undefined,
-                    color: siteConfig.ctaButton?.textColor || undefined
+                    backgroundColor:
+                      siteConfig.ctaButton?.backgroundColor || undefined,
+                    color: siteConfig.ctaButton?.textColor || undefined,
                   }}
-                  onClick={() => setIsMobileMenuOpen(false)}
                 >
                   <Phone className="w-4 h-4 animate-pulse-slow" />
                   {emergencyText}
                 </a>
-              </div>
-            )}
-          </div>
+              )}
+            </div>
+
+            {/* Mobile Menu Button */}
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsMobileMenuOpen(!isMobileMenuOpen);
+              }}
+              className="lg:hidden p-2 rounded-md transition-colors duration-300 text-white hover:bg-white/10"
+              aria-label="Toggle navigation menu"
+            >
+              {isMobileMenuOpen ? (
+                <X className="w-6 h-6" />
+              ) : (
+                <Menu className="w-6 h-6" />
+              )}
+            </button>
+          </nav>
         </div>
-      )}
-    </header>
+
+        {/* Mobile Menu */}
+        {isMobileMenuOpen && (
+          <div className="lg:hidden bg-white border-t border-healthcare-border shadow-lg">
+            <div className="container-custom py-4">
+              <div className="space-y-1">
+                {siteConfig.navigation?.main?.map((item) => (
+                  <div key={item.id}>
+                    {item.children && item.children.length > 0 ? (
+                      <div>
+                        <button
+                          onClick={() =>
+                            setActiveDropdown(
+                              activeDropdown === item.id ? null : item.id,
+                            )
+                          }
+                          className="flex items-center justify-between w-full py-3 text-healthcare-primary hover:text-healthcare-primary-light font-medium"
+                        >
+                          {item.label}
+                          <ChevronDown
+                            className={cn(
+                              "w-4 h-4 transition-transform duration-300",
+                              activeDropdown === item.id && "rotate-180",
+                            )}
+                          />
+                        </button>
+                        {activeDropdown === item.id && (
+                          <div className="pl-4 space-y-1">
+                            {item.children.map((child) => (
+                              <Link
+                                key={child.id}
+                                href={child.href}
+                                className="block py-2 text-healthcare-text-muted hover:text-healthcare-primary"
+                                onClick={() => setIsMobileMenuOpen(false)}
+                              >
+                                {child.label}
+                              </Link>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    ) : (
+                      <Link
+                        href={item.href}
+                        className="block py-3 text-healthcare-primary hover:text-healthcare-primary-light font-medium"
+                        onClick={() => setIsMobileMenuOpen(false)}
+                        target={item.isExternal ? "_blank" : undefined}
+                        rel={
+                          item.isExternal ? "noopener noreferrer" : undefined
+                        }
+                      >
+                        {item.label}
+                      </Link>
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              {/* Mobile Emergency Button */}
+              {emergencyPhone && (
+                <div className="mt-4 pt-4 border-t border-healthcare-border">
+                  <a
+                    href={`tel:${emergencyPhone}`}
+                    className={cn(
+                      "flex items-center justify-center gap-2 w-full px-6 py-3 rounded-lg font-medium transition-all duration-300 animate-pulse-slow",
+                      "bg-healthcare-accent-green hover:bg-healthcare-accent-hover text-white",
+                      "relative before:absolute before:inset-0 before:rounded-lg before:bg-healthcare-accent-green before:animate-ping-slow before:opacity-20",
+                    )}
+                    style={{
+                      backgroundColor:
+                        siteConfig.ctaButton?.backgroundColor || undefined,
+                      color: siteConfig.ctaButton?.textColor || undefined,
+                    }}
+                    onClick={() => setIsMobileMenuOpen(false)}
+                  >
+                    <Phone className="w-4 h-4 animate-pulse-slow" />
+                    {emergencyText}
+                  </a>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </header>
     </>
-  )
+  );
 }

--- a/src/lib/strapi/client.ts
+++ b/src/lib/strapi/client.ts
@@ -1,59 +1,66 @@
 export class StrapiClient {
-  private baseUrl: string
-  private siteId = 'zweitmeinu-ng' // Updated with real site identifier
+  private baseUrl: string;
+  private siteId = "zweitmeinu-ng"; // Updated with real site identifier
 
   constructor() {
-    this.baseUrl = process.env.STRAPI_API_URL || 'https://st.zh3.de/api'
+    this.baseUrl =
+      process.env.STRAPI_API_URL || process.env.NEXT_PUBLIC_STRAPI_URL || "";
   }
 
   async get<T>(endpoint: string, params?: Record<string, any>): Promise<T> {
-    const queryString = params ? `?${new URLSearchParams(params).toString()}` : ''
-    const url = `${this.baseUrl}${endpoint}${queryString}`
+    const queryString = params
+      ? `?${new URLSearchParams(params).toString()}`
+      : "";
+    const url = `${this.baseUrl}${endpoint}${queryString}`;
 
     try {
       const response = await fetch(url, {
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         next: {
           revalidate: 60, // Cache für 60 Sekunden
-          tags: ['strapi'] // Cache tag für revalidation
-        }
-      })
+          tags: ["strapi"], // Cache tag für revalidation
+        },
+      });
 
       if (!response.ok) {
-        throw new Error(`API Error: ${response.status} - ${response.statusText}`)
+        throw new Error(
+          `API Error: ${response.status} - ${response.statusText}`,
+        );
       }
 
-      const data = await response.json()
-      return data
+      const data = await response.json();
+      return data;
     } catch (error) {
-      console.error('Strapi API Error:', error)
-      throw error
+      console.error("Strapi API Error:", error);
+      throw error;
     }
   }
 
   async post<T>(endpoint: string, body?: any): Promise<T> {
-    const url = `${this.baseUrl}${endpoint}`
+    const url = `${this.baseUrl}${endpoint}`;
 
     try {
       const response = await fetch(url, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify(body),
-      })
+      });
 
       if (!response.ok) {
-        throw new Error(`API Error: ${response.status} - ${response.statusText}`)
+        throw new Error(
+          `API Error: ${response.status} - ${response.statusText}`,
+        );
       }
 
-      const data = await response.json()
-      return data
+      const data = await response.json();
+      return data;
     } catch (error) {
-      console.error('Strapi API Error:', error)
-      throw error
+      console.error("Strapi API Error:", error);
+      throw error;
     }
   }
 
@@ -61,33 +68,35 @@ export class StrapiClient {
    * Helper method to build populate parameters for nested relationships
    */
   buildPopulateParams(fields: string[]): Record<string, string> {
-    const params: Record<string, string> = {}
+    const params: Record<string, string> = {};
 
     fields.forEach((field, index) => {
-      params[`populate[${index}]`] = field
-    })
+      params[`populate[${index}]`] = field;
+    });
 
-    return params
+    return params;
   }
 
   /**
    * Helper method to build filter parameters for site-specific queries
    * NOTE: This Strapi instance uses a different data structure without 'sites' relation
    */
-  buildSiteFilter(additionalFilters?: Record<string, any>): Record<string, any> {
+  buildSiteFilter(
+    additionalFilters?: Record<string, any>,
+  ): Record<string, any> {
     const filters: Record<string, any> = {
       // Note: Based on exploration, this Strapi doesn't use site filtering on pages
       // Pages are already filtered by the specific site setup
-    }
+    };
 
     if (additionalFilters) {
       Object.entries(additionalFilters).forEach(([key, value]) => {
-        filters[key] = value
-      })
+        filters[key] = value;
+      });
     }
 
-    return filters
+    return filters;
   }
 }
 
-export const strapiClient = new StrapiClient()
+export const strapiClient = new StrapiClient();

--- a/src/lib/strapi/faq.ts
+++ b/src/lib/strapi/faq.ts
@@ -1,541 +1,687 @@
-import type { StrapiResponse } from '@/types/strapi'
-import type { Page } from '@/types/strapi'
+import type { StrapiResponse } from "@/types/strapi";
+import type { Page } from "@/types/strapi";
 
-const BASE_URL = 'https://st.zh3.de/api'
+const BASE_URL = process.env.NEXT_PUBLIC_STRAPI_URL || "";
 
 // FAQ Data Types
 export interface FAQCategory {
-  id: number
-  documentId: string
-  name: string
-  slug: string
-  description: string
-  icon: string
-  color: string
-  order: number
-  createdAt: string
-  updatedAt: string
-  publishedAt: string
+  id: number;
+  documentId: string;
+  name: string;
+  slug: string;
+  description: string;
+  icon: string;
+  color: string;
+  order: number;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
 }
 
 export interface FAQ {
-  id: number
-  documentId: string
-  question: string
-  slug: string
-  answer: string
-  shortAnswer?: string
-  tags?: string[]
-  priority: 'low' | 'medium' | 'high' | 'featured'
-  helpfulCount: number
-  notHelpfulCount: number
-  videoUrl?: string
-  lastUpdated?: string
-  attachments?: any
-  seo?: any
-  createdAt: string
-  updatedAt: string
-  publishedAt: string
-  category?: FAQCategory
-  relatedServices?: any[]
-  relatedExperts?: any[]
-  relatedFaqs?: any[]
+  id: number;
+  documentId: string;
+  question: string;
+  slug: string;
+  answer: string;
+  shortAnswer?: string;
+  tags?: string[];
+  priority: "low" | "medium" | "high" | "featured";
+  helpfulCount: number;
+  notHelpfulCount: number;
+  videoUrl?: string;
+  lastUpdated?: string;
+  attachments?: any;
+  seo?: any;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+  category?: FAQCategory;
+  relatedServices?: any[];
+  relatedExperts?: any[];
+  relatedFaqs?: any[];
 }
 
 export interface FAQPage {
-  id: number
-  documentId: string
-  title: string
-  slug: string
-  sections: any[]
-  seo?: any
-  createdAt: string
-  updatedAt: string
-  publishedAt: string
+  id: number;
+  documentId: string;
+  title: string;
+  slug: string;
+  sections: any[];
+  seo?: any;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
 }
 
 // Search Types
 export interface FAQSearchResult extends FAQ {
-  score: number
-  matchType: 'question' | 'answer' | 'both'
-  highlightedQuestion?: string
-  highlightedAnswer?: string
+  score: number;
+  matchType: "question" | "answer" | "both";
+  highlightedQuestion?: string;
+  highlightedAnswer?: string;
 }
 
 export interface FAQSearchOptions {
-  term: string
-  categories?: string[]
-  priority?: string[]
-  limit?: number
-  includeAnswers?: boolean
+  term: string;
+  categories?: string[];
+  priority?: string[];
+  limit?: number;
+  includeAnswers?: boolean;
 }
 
 export interface FAQSearchResponse {
-  results: FAQSearchResult[]
-  total: number
-  searchTerm: string
-  suggestions?: string[]
-  categories: { [key: string]: number }
+  results: FAQSearchResult[];
+  total: number;
+  searchTerm: string;
+  suggestions?: string[];
+  categories: { [key: string]: number };
 }
 
 // Enhanced Categorization Strategy Types
 export interface CategorizationStats {
-  totalFAQs: number
-  strapiRelations: number
-  keywordBased: number
-  uncategorized: number
-  method: 'hybrid' | 'relations-only' | 'keywords-only'
-  confidence: number
-  apiHealth: 'healthy' | 'degraded' | 'failed'
-  cacheHits: number
-  processingTime: number
-  categoryDistribution: { [key: string]: number }
+  totalFAQs: number;
+  strapiRelations: number;
+  keywordBased: number;
+  uncategorized: number;
+  method: "hybrid" | "relations-only" | "keywords-only";
+  confidence: number;
+  apiHealth: "healthy" | "degraded" | "failed";
+  cacheHits: number;
+  processingTime: number;
+  categoryDistribution: { [key: string]: number };
 }
 
 export interface CategorizationQuality {
-  overallScore: number
-  relationsCoverage: number
-  keywordAccuracy: number
-  categoryCoverage: number
-  recommendations: string[]
+  overallScore: number;
+  relationsCoverage: number;
+  keywordAccuracy: number;
+  categoryCoverage: number;
+  recommendations: string[];
 }
 
 // Enhanced caching system
 interface CachedCategorizationResult {
-  faqId: number
-  categorySlug: string | null
-  method: 'relations' | 'keywords'
-  confidence: number
-  timestamp: number
-  ttl: number
+  faqId: number;
+  categorySlug: string | null;
+  method: "relations" | "keywords";
+  confidence: number;
+  timestamp: number;
+  ttl: number;
 }
 
 // Cache for categorization results (5 minutes TTL)
-const CATEGORIZATION_CACHE = new Map<number, CachedCategorizationResult>()
-const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+const CATEGORIZATION_CACHE = new Map<number, CachedCategorizationResult>();
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
 // Enhanced Category Keywords Mapping with confidence scores
 const CATEGORY_KEYWORDS = {
-  'zweitmeinung-gallenblase': {
-    primary: ['gallenblase', 'gallenstein', 'cholezystektomie'],
-    secondary: ['gallen', 'gallensteine', 'gallenblasenentfernung', 'gallenkolik', 'cholangitis'],
-    confidence: 0.9
+  "zweitmeinung-gallenblase": {
+    primary: ["gallenblase", "gallenstein", "cholezystektomie"],
+    secondary: [
+      "gallen",
+      "gallensteine",
+      "gallenblasenentfernung",
+      "gallenkolik",
+      "cholangitis",
+    ],
+    confidence: 0.9,
   },
-  'zweitmeinung-nephrologie': {
-    primary: ['niere', 'dialyse', 'niereninsuffizienz'],
-    secondary: ['nieren', 'nierenerkrankung', 'nephro', 'transplantation', 'hämodialyse', 'peritonealdialyse', 'nierenversagen'],
-    confidence: 0.85
+  "zweitmeinung-nephrologie": {
+    primary: ["niere", "dialyse", "niereninsuffizienz"],
+    secondary: [
+      "nieren",
+      "nierenerkrankung",
+      "nephro",
+      "transplantation",
+      "hämodialyse",
+      "peritonealdialyse",
+      "nierenversagen",
+    ],
+    confidence: 0.85,
   },
-  'zweitmeinung-kardiologie': {
-    primary: ['herz', 'herzinfarkt', 'bypass'],
-    secondary: ['kardio', 'katheter', 'herzkatheter', 'stent', 'koronararterien', 'angioplastie', 'herzrhythmus', 'schrittmacher'],
-    confidence: 0.9
+  "zweitmeinung-kardiologie": {
+    primary: ["herz", "herzinfarkt", "bypass"],
+    secondary: [
+      "kardio",
+      "katheter",
+      "herzkatheter",
+      "stent",
+      "koronararterien",
+      "angioplastie",
+      "herzrhythmus",
+      "schrittmacher",
+    ],
+    confidence: 0.9,
   },
-  'zweitmeinung-onkologie': {
-    primary: ['krebs', 'tumor', 'chemotherapie'],
-    secondary: ['onko', 'chemo', 'bestrahlung', 'strahlentherapie', 'karzinom', 'metastasen', 'biopsie', 'malignom', 'zytostatika'],
-    confidence: 0.95
+  "zweitmeinung-onkologie": {
+    primary: ["krebs", "tumor", "chemotherapie"],
+    secondary: [
+      "onko",
+      "chemo",
+      "bestrahlung",
+      "strahlentherapie",
+      "karzinom",
+      "metastasen",
+      "biopsie",
+      "malignom",
+      "zytostatika",
+    ],
+    confidence: 0.95,
   },
-  'zweitmeinung-intensivmedizin': {
-    primary: ['intensiv', 'intensivstation', 'beatmung'],
-    secondary: ['notfall', 'reanimation', 'sepsis', 'schock', 'koma', 'icu', 'lebenserhaltung', 'organversagen'],
-    confidence: 0.8
+  "zweitmeinung-intensivmedizin": {
+    primary: ["intensiv", "intensivstation", "beatmung"],
+    secondary: [
+      "notfall",
+      "reanimation",
+      "sepsis",
+      "schock",
+      "koma",
+      "icu",
+      "lebenserhaltung",
+      "organversagen",
+    ],
+    confidence: 0.8,
   },
-  'zweitmeinung-schilddruese': {
-    primary: ['schilddrüse', 'thyroid', 'thyreoidektomie'],
-    secondary: ['schild', 'struma', 'schilddrüsenknoten', 'tsh', 'hyperthyreose', 'hypothyreose', 'autonomie'],
-    confidence: 0.85
+  "zweitmeinung-schilddruese": {
+    primary: ["schilddrüse", "thyroid", "thyreoidektomie"],
+    secondary: [
+      "schild",
+      "struma",
+      "schilddrüsenknoten",
+      "tsh",
+      "hyperthyreose",
+      "hypothyreose",
+      "autonomie",
+    ],
+    confidence: 0.85,
   },
-  'allgemeine-fragen-zur-zweitmeinung': {
-    primary: ['zweitmeinung', 'gutachten', 'experten'],
-    secondary: ['ablauf', 'kosten', 'verfahren', 'beratung', 'meinung', 'einschätzung', 'diagnose', 'behandlung', 'therapie'],
-    confidence: 0.7
-  }
-}
+  "allgemeine-fragen-zur-zweitmeinung": {
+    primary: ["zweitmeinung", "gutachten", "experten"],
+    secondary: [
+      "ablauf",
+      "kosten",
+      "verfahren",
+      "beratung",
+      "meinung",
+      "einschätzung",
+      "diagnose",
+      "behandlung",
+      "therapie",
+    ],
+    confidence: 0.7,
+  },
+};
 
 // API Functions
 export async function getFAQPage(): Promise<FAQPage | null> {
   try {
-    const response = await fetch(`${BASE_URL}/pages?filters[slug][$eq]=faq&populate=*`, {
-      headers: {
-        'Content-Type': 'application/json',
+    const response = await fetch(
+      `${BASE_URL}/pages?filters[slug][$eq]=faq&populate=*`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        cache: "no-store",
       },
-      cache: 'no-store'
-    })
+    );
 
     if (!response.ok) {
-      console.error('Failed to fetch FAQ page:', response.statusText)
-      return null
+      console.error("Failed to fetch FAQ page:", response.statusText);
+      return null;
     }
 
-    const data: StrapiResponse<FAQPage[]> = await response.json()
-    console.log('✅ FAQ Page loaded:', data.data?.[0]?.title)
+    const data: StrapiResponse<FAQPage[]> = await response.json();
+    console.log("✅ FAQ Page loaded:", data.data?.[0]?.title);
 
-    return data.data?.[0] || null
+    return data.data?.[0] || null;
   } catch (error) {
-    console.error('Error fetching FAQ page:', error)
-    return null
+    console.error("Error fetching FAQ page:", error);
+    return null;
   }
 }
 
 export async function getFAQCategories(): Promise<FAQCategory[]> {
   try {
-    const response = await fetch(`${BASE_URL}/faq-categories?sort=order:asc&populate=*`, {
-      headers: {
-        'Content-Type': 'application/json',
+    const response = await fetch(
+      `${BASE_URL}/faq-categories?sort=order:asc&populate=*`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        cache: "no-store",
       },
-      cache: 'no-store'
-    })
+    );
 
     if (!response.ok) {
-      console.error('Failed to fetch FAQ categories:', response.statusText)
-      return []
+      console.error("Failed to fetch FAQ categories:", response.statusText);
+      return [];
     }
 
-    const data: StrapiResponse<FAQCategory[]> = await response.json()
-    console.log('✅ FAQ Categories loaded:', data.data?.length)
+    const data: StrapiResponse<FAQCategory[]> = await response.json();
+    console.log("✅ FAQ Categories loaded:", data.data?.length);
 
-    return data.data || []
+    return data.data || [];
   } catch (error) {
-    console.error('Error fetching FAQ categories:', error)
-    return []
+    console.error("Error fetching FAQ categories:", error);
+    return [];
   }
 }
 
 export async function getFAQs(limit = 25): Promise<FAQ[]> {
   try {
-    const response = await fetch(`${BASE_URL}/faqs?sort=priority:desc,helpfulCount:desc&pagination[limit]=${limit}&populate=*`, {
-      headers: {
-        'Content-Type': 'application/json',
+    const response = await fetch(
+      `${BASE_URL}/faqs?sort=priority:desc,helpfulCount:desc&pagination[limit]=${limit}&populate=*`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        cache: "no-store",
       },
-      cache: 'no-store'
-    })
+    );
 
     if (!response.ok) {
-      console.error('Failed to fetch FAQs:', response.statusText)
-      return []
+      console.error("Failed to fetch FAQs:", response.statusText);
+      return [];
     }
 
-    const data: StrapiResponse<FAQ[]> = await response.json()
-    console.log('✅ FAQs loaded:', data.data?.length)
+    const data: StrapiResponse<FAQ[]> = await response.json();
+    console.log("✅ FAQs loaded:", data.data?.length);
 
-    return data.data || []
+    return data.data || [];
   } catch (error) {
-    console.error('Error fetching FAQs:', error)
-    return []
+    console.error("Error fetching FAQs:", error);
+    return [];
   }
 }
 
-export async function getFAQsByCategory(categorySlug: string, limit = 10): Promise<FAQ[]> {
-  const startTime = Date.now()
+export async function getFAQsByCategory(
+  categorySlug: string,
+  limit = 10,
+): Promise<FAQ[]> {
+  const startTime = Date.now();
 
   try {
     // Enhanced Strapi category relations test with detailed logging
-    console.log(`🔍 Enhanced category test for ${categorySlug}...`)
+    console.log(`🔍 Enhanced category test for ${categorySlug}...`);
 
     // Try comprehensive Strapi filter approaches
     const filterApproaches = [
-      { query: `filters[category][slug][$eq]=${categorySlug}`, description: 'by category slug exact match' },
-      { query: `filters[category][documentId][$eq]=${categorySlug}`, description: 'by category documentId' },
-      { query: `filters[category][name][$containsi]=${categorySlug.replace(/[-_]/g, ' ')}`, description: 'by category name contains' },
-      { query: `filters[category][id][$in]=${categorySlug}`, description: 'by category ID (if numeric)' }
-    ]
+      {
+        query: `filters[category][slug][$eq]=${categorySlug}`,
+        description: "by category slug exact match",
+      },
+      {
+        query: `filters[category][documentId][$eq]=${categorySlug}`,
+        description: "by category documentId",
+      },
+      {
+        query: `filters[category][name][$containsi]=${categorySlug.replace(/[-_]/g, " ")}`,
+        description: "by category name contains",
+      },
+      {
+        query: `filters[category][id][$in]=${categorySlug}`,
+        description: "by category ID (if numeric)",
+      },
+    ];
 
-    let strapiFilteredFAQs: FAQ[] = []
-    let successfulMethod = ''
+    let strapiFilteredFAQs: FAQ[] = [];
+    let successfulMethod = "";
 
     for (const approach of filterApproaches) {
       try {
-        console.log(`   🔎 Trying: ${approach.description}...`)
-        const response = await fetch(`${BASE_URL}/faqs?${approach.query}&sort=priority:desc,helpfulCount:desc&pagination[limit]=${limit}&populate=category`, {
-          headers: { 'Content-Type': 'application/json' },
-          cache: 'no-store',
-          signal: AbortSignal.timeout(5000)
-        })
+        console.log(`   🔎 Trying: ${approach.description}...`);
+        const response = await fetch(
+          `${BASE_URL}/faqs?${approach.query}&sort=priority:desc,helpfulCount:desc&pagination[limit]=${limit}&populate=category`,
+          {
+            headers: { "Content-Type": "application/json" },
+            cache: "no-store",
+            signal: AbortSignal.timeout(5000),
+          },
+        );
 
         if (response.ok) {
-          const data: StrapiResponse<FAQ[]> = await response.json()
+          const data: StrapiResponse<FAQ[]> = await response.json();
           if (data.data && data.data.length > 0) {
-            strapiFilteredFAQs = data.data
-            successfulMethod = approach.description
-            console.log(`   ✅ SUCCESS via ${approach.description}: ${strapiFilteredFAQs.length} FAQs found`)
+            strapiFilteredFAQs = data.data;
+            successfulMethod = approach.description;
+            console.log(
+              `   ✅ SUCCESS via ${approach.description}: ${strapiFilteredFAQs.length} FAQs found`,
+            );
 
             // Log the category relations found
             strapiFilteredFAQs.forEach((faq, i) => {
               if (faq.category) {
-                console.log(`     FAQ ${i + 1}: ${faq.category.name} (${faq.category.slug})`)
+                console.log(
+                  `     FAQ ${i + 1}: ${faq.category.name} (${faq.category.slug})`,
+                );
               }
-            })
-            break
+            });
+            break;
           } else {
-            console.log(`     ⚪ No results via ${approach.description}`)
+            console.log(`     ⚪ No results via ${approach.description}`);
           }
         } else {
-          console.log(`     ❌ Failed via ${approach.description}: ${response.status}`)
+          console.log(
+            `     ❌ Failed via ${approach.description}: ${response.status}`,
+          );
         }
       } catch (error) {
-        console.log(`     ⚠️ Error via ${approach.description}: ${error instanceof Error ? error.message : 'Unknown error'}`)
+        console.log(
+          `     ⚠️ Error via ${approach.description}: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
       }
     }
 
     // If Strapi relations worked, use them
     if (strapiFilteredFAQs.length > 0) {
-      const processingTime = Date.now() - startTime
-      console.log(`🎯 API Relations SUCCESS for ${categorySlug}: ${strapiFilteredFAQs.length} FAQs (${processingTime}ms) via ${successfulMethod}`)
-      return strapiFilteredFAQs
+      const processingTime = Date.now() - startTime;
+      console.log(
+        `🎯 API Relations SUCCESS for ${categorySlug}: ${strapiFilteredFAQs.length} FAQs (${processingTime}ms) via ${successfulMethod}`,
+      );
+      return strapiFilteredFAQs;
     }
 
     // Enhanced fallback to keyword-based filtering
-    console.log(`🔄 API relations failed for ${categorySlug}, using enhanced keyword categorization...`)
+    console.log(
+      `🔄 API relations failed for ${categorySlug}, using enhanced keyword categorization...`,
+    );
 
-    const allFAQs = await getFAQs(100) // Get more FAQs
-    const categoryKeywords = CATEGORY_KEYWORDS[categorySlug as keyof typeof CATEGORY_KEYWORDS]
+    const allFAQs = await getFAQs(100); // Get more FAQs
+    const categoryKeywords =
+      CATEGORY_KEYWORDS[categorySlug as keyof typeof CATEGORY_KEYWORDS];
 
     if (!categoryKeywords) {
-      console.warn(`❌ No keywords defined for category: ${categorySlug}`)
-      return []
+      console.warn(`❌ No keywords defined for category: ${categorySlug}`);
+      return [];
     }
 
-    const { primary, secondary, confidence } = categoryKeywords
-    const keywordFilteredFAQs: Array<FAQ & { matchScore: number }> = []
+    const { primary, secondary, confidence } = categoryKeywords;
+    const keywordFilteredFAQs: Array<FAQ & { matchScore: number }> = [];
 
-    allFAQs.forEach(faq => {
-      const text = `${faq.question} ${faq.answer}`.toLowerCase()
-      let score = 0
+    allFAQs.forEach((faq) => {
+      const text = `${faq.question} ${faq.answer}`.toLowerCase();
+      let score = 0;
 
       // Enhanced keyword matching
-      primary.forEach(keyword => {
+      primary.forEach((keyword) => {
         if (text.includes(keyword.toLowerCase())) {
-          score += 3
+          score += 3;
         }
-      })
+      });
 
-      secondary.forEach(keyword => {
+      secondary.forEach((keyword) => {
         if (text.includes(keyword.toLowerCase())) {
-          score += 1
+          score += 1;
         }
-      })
+      });
 
       if (score > 0) {
-        keywordFilteredFAQs.push({ ...faq, matchScore: score })
-        console.log(`   🔤 Keyword match: FAQ ${faq.id} score=${score}`)
+        keywordFilteredFAQs.push({ ...faq, matchScore: score });
+        console.log(`   🔤 Keyword match: FAQ ${faq.id} score=${score}`);
       }
-    })
+    });
 
     // Sort by match score, then priority, then helpful count
     const sortedFAQs = keywordFilteredFAQs
       .sort((a, b) => {
-        if (a.matchScore !== b.matchScore) return b.matchScore - a.matchScore
+        if (a.matchScore !== b.matchScore) return b.matchScore - a.matchScore;
 
-        const priorityOrder = { featured: 4, high: 3, medium: 2, low: 1 }
-        const aPriority = priorityOrder[a.priority]
-        const bPriority = priorityOrder[b.priority]
+        const priorityOrder = { featured: 4, high: 3, medium: 2, low: 1 };
+        const aPriority = priorityOrder[a.priority];
+        const bPriority = priorityOrder[b.priority];
 
-        if (aPriority !== bPriority) return bPriority - aPriority
-        return b.helpfulCount - a.helpfulCount
+        if (aPriority !== bPriority) return bPriority - aPriority;
+        return b.helpfulCount - a.helpfulCount;
       })
       .slice(0, limit)
-      .map(({ matchScore, ...faq }) => faq) // Remove matchScore from final result
+      .map(({ matchScore, ...faq }) => faq); // Remove matchScore from final result
 
-    const processingTime = Date.now() - startTime
-    console.log(`✅ Keyword categorization for ${categorySlug}: ${sortedFAQs.length} FAQs (${processingTime}ms, confidence: ${confidence})`)
+    const processingTime = Date.now() - startTime;
+    console.log(
+      `✅ Keyword categorization for ${categorySlug}: ${sortedFAQs.length} FAQs (${processingTime}ms, confidence: ${confidence})`,
+    );
 
-    return sortedFAQs
+    return sortedFAQs;
   } catch (error) {
-    console.error('Error fetching FAQs by category:', error)
-    return []
+    console.error("Error fetching FAQs by category:", error);
+    return [];
   }
 }
 
 // Search Functions
-export async function searchFAQs(searchTerm: string, limit = 20): Promise<FAQ[]> {
+export async function searchFAQs(
+  searchTerm: string,
+  limit = 20,
+): Promise<FAQ[]> {
   try {
-    const encodedSearch = encodeURIComponent(searchTerm)
-    const response = await fetch(`${BASE_URL}/faqs?filters[question][$containsi]=${encodedSearch}&sort=priority:desc,helpfulCount:desc&pagination[limit]=${limit}&populate=*`, {
-      headers: {
-        'Content-Type': 'application/json',
+    const encodedSearch = encodeURIComponent(searchTerm);
+    const response = await fetch(
+      `${BASE_URL}/faqs?filters[question][$containsi]=${encodedSearch}&sort=priority:desc,helpfulCount:desc&pagination[limit]=${limit}&populate=*`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        cache: "no-store",
       },
-      cache: 'no-store'
-    })
+    );
 
     if (!response.ok) {
-      console.error('Failed to search FAQs:', response.statusText)
-      return []
+      console.error("Failed to search FAQs:", response.statusText);
+      return [];
     }
 
-    const data: StrapiResponse<FAQ[]> = await response.json()
-    console.log('✅ FAQ search results:', data.data?.length, 'for term:', searchTerm)
+    const data: StrapiResponse<FAQ[]> = await response.json();
+    console.log(
+      "✅ FAQ search results:",
+      data.data?.length,
+      "for term:",
+      searchTerm,
+    );
 
-    return data.data || []
+    return data.data || [];
   } catch (error) {
-    console.error('Error searching FAQs:', error)
-    return []
+    console.error("Error searching FAQs:", error);
+    return [];
   }
 }
 
-export async function advancedFAQSearch(options: FAQSearchOptions): Promise<FAQSearchResponse> {
+export async function advancedFAQSearch(
+  options: FAQSearchOptions,
+): Promise<FAQSearchResponse> {
   try {
-    const { term, categories, priority, limit = 20, includeAnswers = true } = options
+    const {
+      term,
+      categories,
+      priority,
+      limit = 20,
+      includeAnswers = true,
+    } = options;
 
-    const encodedTerm = encodeURIComponent(term)
-    const questionQuery = `filters[question][$containsi]=${encodedTerm}`
+    const encodedTerm = encodeURIComponent(term);
+    const questionQuery = `filters[question][$containsi]=${encodedTerm}`;
 
-    const questionResponse = await fetch(`${BASE_URL}/faqs?${questionQuery}&sort=priority:desc,helpfulCount:desc&pagination[limit]=${limit}&populate=*`, {
-      headers: {
-        'Content-Type': 'application/json',
+    const questionResponse = await fetch(
+      `${BASE_URL}/faqs?${questionQuery}&sort=priority:desc,helpfulCount:desc&pagination[limit]=${limit}&populate=*`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        cache: "no-store",
       },
-      cache: 'no-store'
-    })
+    );
 
-    let questionResults: FAQ[] = []
+    let questionResults: FAQ[] = [];
     if (questionResponse.ok) {
-      const questionData: StrapiResponse<FAQ[]> = await questionResponse.json()
-      questionResults = questionData.data || []
+      const questionData: StrapiResponse<FAQ[]> = await questionResponse.json();
+      questionResults = questionData.data || [];
     }
 
-    let answerResults: FAQ[] = []
+    let answerResults: FAQ[] = [];
     if (includeAnswers) {
-      const answerQuery = `filters[answer][$containsi]=${encodedTerm}`
-      const answerResponse = await fetch(`${BASE_URL}/faqs?${answerQuery}&sort=priority:desc,helpfulCount:desc&pagination[limit]=${limit}&populate=*`, {
-        headers: {
-          'Content-Type': 'application/json',
+      const answerQuery = `filters[answer][$containsi]=${encodedTerm}`;
+      const answerResponse = await fetch(
+        `${BASE_URL}/faqs?${answerQuery}&sort=priority:desc,helpfulCount:desc&pagination[limit]=${limit}&populate=*`,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          cache: "no-store",
         },
-        cache: 'no-store'
-      })
+      );
 
       if (answerResponse.ok) {
-        const answerData: StrapiResponse<FAQ[]> = await answerResponse.json()
-        answerResults = answerData.data || []
+        const answerData: StrapiResponse<FAQ[]> = await answerResponse.json();
+        answerResults = answerData.data || [];
       }
     }
 
-    const allResults = new Map<number, FAQSearchResult>()
+    const allResults = new Map<number, FAQSearchResult>();
 
-    questionResults.forEach(faq => {
+    questionResults.forEach((faq) => {
       const searchResult: FAQSearchResult = {
         ...faq,
-        score: calculateSearchScore(faq, term, 'question'),
-        matchType: 'question',
+        score: calculateSearchScore(faq, term, "question"),
+        matchType: "question",
         highlightedQuestion: highlightText(faq.question, term),
-        highlightedAnswer: faq.answer
-      }
-      allResults.set(faq.id, searchResult)
-    })
+        highlightedAnswer: faq.answer,
+      };
+      allResults.set(faq.id, searchResult);
+    });
 
-    answerResults.forEach(faq => {
+    answerResults.forEach((faq) => {
       if (allResults.has(faq.id)) {
-        const existing = allResults.get(faq.id)!
-        existing.matchType = 'both'
-        existing.score = Math.max(existing.score, calculateSearchScore(faq, term, 'answer'))
-        existing.highlightedAnswer = highlightText(faq.answer, term)
+        const existing = allResults.get(faq.id)!;
+        existing.matchType = "both";
+        existing.score = Math.max(
+          existing.score,
+          calculateSearchScore(faq, term, "answer"),
+        );
+        existing.highlightedAnswer = highlightText(faq.answer, term);
       } else {
         const searchResult: FAQSearchResult = {
           ...faq,
-          score: calculateSearchScore(faq, term, 'answer'),
-          matchType: 'answer',
+          score: calculateSearchScore(faq, term, "answer"),
+          matchType: "answer",
           highlightedQuestion: faq.question,
-          highlightedAnswer: highlightText(faq.answer, term)
-        }
-        allResults.set(faq.id, searchResult)
+          highlightedAnswer: highlightText(faq.answer, term),
+        };
+        allResults.set(faq.id, searchResult);
       }
-    })
+    });
 
     const sortedResults = Array.from(allResults.values()).sort((a, b) => {
-      if (a.score !== b.score) return b.score - a.score
+      if (a.score !== b.score) return b.score - a.score;
       if (a.priority !== b.priority) {
-        const priorityOrder = { featured: 4, high: 3, medium: 2, low: 1 }
-        return priorityOrder[b.priority] - priorityOrder[a.priority]
+        const priorityOrder = { featured: 4, high: 3, medium: 2, low: 1 };
+        return priorityOrder[b.priority] - priorityOrder[a.priority];
       }
-      return b.helpfulCount - a.helpfulCount
-    })
+      return b.helpfulCount - a.helpfulCount;
+    });
 
-    const categoryDistribution: { [key: string]: number } = {}
-    sortedResults.forEach(result => {
-      const matchedCategory = intelligentCategorizeFrequentlyAskedQuestion(result)
+    const categoryDistribution: { [key: string]: number } = {};
+    sortedResults.forEach((result) => {
+      const matchedCategory =
+        intelligentCategorizeFrequentlyAskedQuestion(result);
       if (matchedCategory) {
-        categoryDistribution[matchedCategory] = (categoryDistribution[matchedCategory] || 0) + 1
+        categoryDistribution[matchedCategory] =
+          (categoryDistribution[matchedCategory] || 0) + 1;
       }
-    })
+    });
 
-    const suggestions = generateSearchSuggestions(term, sortedResults)
+    const suggestions = generateSearchSuggestions(term, sortedResults);
 
-    console.log('✅ Advanced FAQ search completed:', {
+    console.log("✅ Advanced FAQ search completed:", {
       term,
       totalResults: sortedResults.length,
       questionMatches: questionResults.length,
-      answerMatches: answerResults.length
-    })
+      answerMatches: answerResults.length,
+    });
 
     return {
       results: sortedResults.slice(0, limit),
       total: sortedResults.length,
       searchTerm: term,
       suggestions,
-      categories: categoryDistribution
-    }
+      categories: categoryDistribution,
+    };
   } catch (error) {
-    console.error('Error in advanced FAQ search:', error)
+    console.error("Error in advanced FAQ search:", error);
     return {
       results: [],
       total: 0,
       searchTerm: options.term,
       suggestions: [],
-      categories: {}
-    }
+      categories: {},
+    };
   }
 }
 
 // Enhanced categorization analysis with detailed metrics
-export function analyzeCategorizationStrategy(faqs: FAQ[]): CategorizationStats {
-  const startTime = Date.now()
-  let strapiRelations = 0
-  let keywordBased = 0
-  let uncategorized = 0
-  const cacheHits = CATEGORIZATION_CACHE.size
-  const categoryDistribution: { [key: string]: number } = {}
+export function analyzeCategorizationStrategy(
+  faqs: FAQ[],
+): CategorizationStats {
+  const startTime = Date.now();
+  let strapiRelations = 0;
+  let keywordBased = 0;
+  let uncategorized = 0;
+  const cacheHits = CATEGORIZATION_CACHE.size;
+  const categoryDistribution: { [key: string]: number } = {};
 
-  let relationQuality = 0
-  let totalFAQsChecked = 0
+  let relationQuality = 0;
+  let totalFAQsChecked = 0;
 
-  faqs.forEach(faq => {
-    totalFAQsChecked++
+  faqs.forEach((faq) => {
+    totalFAQsChecked++;
 
     // Enhanced API relation detection
     if (faq.category && faq.category.slug && faq.category.name) {
-      strapiRelations++
-      relationQuality += 1.0
-      categoryDistribution[faq.category.slug] = (categoryDistribution[faq.category.slug] || 0) + 1
-      console.log(`🎯 API Relation: FAQ ${faq.id} → ${faq.category.name} (${faq.category.slug})`)
+      strapiRelations++;
+      relationQuality += 1.0;
+      categoryDistribution[faq.category.slug] =
+        (categoryDistribution[faq.category.slug] || 0) + 1;
+      console.log(
+        `🎯 API Relation: FAQ ${faq.id} → ${faq.category.name} (${faq.category.slug})`,
+      );
     } else {
-      const keywordResult = categorizeByKeywordsEnhanced(faq)
+      const keywordResult = categorizeByKeywordsEnhanced(faq);
       if (keywordResult) {
-        keywordBased++
-        relationQuality += keywordResult.confidence
-        categoryDistribution[keywordResult.category] = (categoryDistribution[keywordResult.category] || 0) + 1
-        console.log(`🔤 Keyword Match: FAQ ${faq.id} → ${keywordResult.category} (confidence: ${keywordResult.confidence.toFixed(2)})`)
+        keywordBased++;
+        relationQuality += keywordResult.confidence;
+        categoryDistribution[keywordResult.category] =
+          (categoryDistribution[keywordResult.category] || 0) + 1;
+        console.log(
+          `🔤 Keyword Match: FAQ ${faq.id} → ${keywordResult.category} (confidence: ${keywordResult.confidence.toFixed(2)})`,
+        );
       } else {
-        uncategorized++
-        console.log(`⚠️ Uncategorized: FAQ ${faq.id} - "${faq.question.substring(0, 50)}..."`)
+        uncategorized++;
+        console.log(
+          `⚠️ Uncategorized: FAQ ${faq.id} - "${faq.question.substring(0, 50)}..."`,
+        );
       }
     }
-  })
+  });
 
-  let method: 'hybrid' | 'relations-only' | 'keywords-only'
+  let method: "hybrid" | "relations-only" | "keywords-only";
   if (strapiRelations > 0 && keywordBased > 0) {
-    method = 'hybrid'
+    method = "hybrid";
   } else if (strapiRelations > 0) {
-    method = 'relations-only'
+    method = "relations-only";
   } else {
-    method = 'keywords-only'
+    method = "keywords-only";
   }
 
-  const confidence = totalFAQsChecked > 0 ? relationQuality / totalFAQsChecked : 0
-  const strapiCoverage = strapiRelations / faqs.length
-  const apiHealth: 'healthy' | 'degraded' | 'failed' =
-    strapiCoverage > 0.8 ? 'healthy' :
-    strapiCoverage > 0.3 ? 'degraded' : 'failed'
+  const confidence =
+    totalFAQsChecked > 0 ? relationQuality / totalFAQsChecked : 0;
+  const strapiCoverage = strapiRelations / faqs.length;
+  const apiHealth: "healthy" | "degraded" | "failed" =
+    strapiCoverage > 0.8
+      ? "healthy"
+      : strapiCoverage > 0.3
+        ? "degraded"
+        : "failed";
 
-  const processingTime = Date.now() - startTime
+  const processingTime = Date.now() - startTime;
 
   const stats: CategorizationStats = {
     totalFAQs: faqs.length,
@@ -547,68 +693,89 @@ export function analyzeCategorizationStrategy(faqs: FAQ[]): CategorizationStats 
     apiHealth,
     cacheHits,
     processingTime,
-    categoryDistribution
-  }
+    categoryDistribution,
+  };
 
-  console.log('📊 Enhanced Categorization Strategy Analysis:')
-  console.log(`   📡 Strapi API Relations: ${strapiRelations}/${faqs.length} (${Math.round(strapiCoverage * 100)}%)`)
-  console.log(`   🔤 Keyword-based: ${keywordBased}/${faqs.length} (${Math.round((keywordBased / faqs.length) * 100)}%)`)
-  console.log(`   ❓ Uncategorized: ${uncategorized}/${faqs.length} (${Math.round((uncategorized / faqs.length) * 100)}%)`)
-  console.log(`   🎯 Overall Confidence: ${Math.round(confidence * 100)}%`)
-  console.log(`   🏥 API Health: ${apiHealth}`)
-  console.log(`   ⚡ Processing Time: ${processingTime}ms`)
-  console.log(`   💾 Cache Efficiency: ${cacheHits} entries`)
+  console.log("📊 Enhanced Categorization Strategy Analysis:");
+  console.log(
+    `   📡 Strapi API Relations: ${strapiRelations}/${faqs.length} (${Math.round(strapiCoverage * 100)}%)`,
+  );
+  console.log(
+    `   🔤 Keyword-based: ${keywordBased}/${faqs.length} (${Math.round((keywordBased / faqs.length) * 100)}%)`,
+  );
+  console.log(
+    `   ❓ Uncategorized: ${uncategorized}/${faqs.length} (${Math.round((uncategorized / faqs.length) * 100)}%)`,
+  );
+  console.log(`   🎯 Overall Confidence: ${Math.round(confidence * 100)}%`);
+  console.log(`   🏥 API Health: ${apiHealth}`);
+  console.log(`   ⚡ Processing Time: ${processingTime}ms`);
+  console.log(`   💾 Cache Efficiency: ${cacheHits} entries`);
 
   if (strapiCoverage === 0) {
-    console.log('💡 Recommendation: FAQ category relations are not set up in Strapi. Consider:')
-    console.log('   1. Setting up category relations in Strapi CMS')
-    console.log('   2. Current keyword-based system provides good coverage')
+    console.log(
+      "💡 Recommendation: FAQ category relations are not set up in Strapi. Consider:",
+    );
+    console.log("   1. Setting up category relations in Strapi CMS");
+    console.log("   2. Current keyword-based system provides good coverage");
   } else if (strapiCoverage < 0.5) {
-    console.log('💡 Recommendation: Partial Strapi relations detected. Consider:')
-    console.log('   1. Completing category assignments in Strapi')
-    console.log('   2. Hybrid approach working well')
+    console.log(
+      "💡 Recommendation: Partial Strapi relations detected. Consider:",
+    );
+    console.log("   1. Completing category assignments in Strapi");
+    console.log("   2. Hybrid approach working well");
   } else {
-    console.log('✅ Excellent: High API relation coverage detected!')
+    console.log("✅ Excellent: High API relation coverage detected!");
   }
 
-  return stats
+  return stats;
 }
 
 // Enhanced intelligent categorization
-export function intelligentCategorizeFrequentlyAskedQuestion(faq: FAQ): string | null {
-  const cached = CATEGORIZATION_CACHE.get(faq.id)
+export function intelligentCategorizeFrequentlyAskedQuestion(
+  faq: FAQ,
+): string | null {
+  const cached = CATEGORIZATION_CACHE.get(faq.id);
   if (cached && Date.now() - cached.timestamp < cached.ttl) {
-    console.log(`💾 Cache hit for FAQ ${faq.id}: ${cached.categorySlug} (${cached.method})`)
-    return cached.categorySlug
+    console.log(
+      `💾 Cache hit for FAQ ${faq.id}: ${cached.categorySlug} (${cached.method})`,
+    );
+    return cached.categorySlug;
   }
 
-  let categorySlug: string | null = null
-  let method: 'relations' | 'keywords' = 'relations'
-  let confidence = 0
+  let categorySlug: string | null = null;
+  let method: "relations" | "keywords" = "relations";
+  let confidence = 0;
 
   // PRIMARY: Enhanced Strapi category relation detection
   if (faq.category && faq.category.slug && faq.category.name) {
-    const categoryValid = faq.category.slug.length > 0 && faq.category.name.length > 0
+    const categoryValid =
+      faq.category.slug.length > 0 && faq.category.name.length > 0;
     if (categoryValid) {
-      categorySlug = faq.category.slug
-      method = 'relations'
-      confidence = 1.0
-      console.log(`🎯 Strong API relation for FAQ ${faq.id}: ${categorySlug}`)
+      categorySlug = faq.category.slug;
+      method = "relations";
+      confidence = 1.0;
+      console.log(`🎯 Strong API relation for FAQ ${faq.id}: ${categorySlug}`);
     }
   }
 
   // FALLBACK: Enhanced keyword-based categorization
   if (!categorySlug) {
-    const keywordResult = categorizeByKeywordsEnhanced(faq)
+    const keywordResult = categorizeByKeywordsEnhanced(faq);
     if (keywordResult && keywordResult.confidence > 0.4) {
-      categorySlug = keywordResult.category
-      method = 'keywords'
-      confidence = keywordResult.confidence
-      console.log(`🔤 Keyword categorization for FAQ ${faq.id}: ${categorySlug} (confidence: ${confidence.toFixed(2)})`)
+      categorySlug = keywordResult.category;
+      method = "keywords";
+      confidence = keywordResult.confidence;
+      console.log(
+        `🔤 Keyword categorization for FAQ ${faq.id}: ${categorySlug} (confidence: ${confidence.toFixed(2)})`,
+      );
     } else if (keywordResult) {
-      console.log(`⚠️ Low confidence keyword match for FAQ ${faq.id}: ${keywordResult.category} (${keywordResult.confidence.toFixed(2)}) - skipping`)
+      console.log(
+        `⚠️ Low confidence keyword match for FAQ ${faq.id}: ${keywordResult.category} (${keywordResult.confidence.toFixed(2)}) - skipping`,
+      );
     } else {
-      console.log(`❌ No categorization possible for FAQ ${faq.id}: "${faq.question.substring(0, 50)}..."`)
+      console.log(
+        `❌ No categorization possible for FAQ ${faq.id}: "${faq.question.substring(0, 50)}..."`,
+      );
     }
   }
 
@@ -619,101 +786,149 @@ export function intelligentCategorizeFrequentlyAskedQuestion(faq: FAQ): string |
       method,
       confidence,
       timestamp: Date.now(),
-      ttl: CACHE_TTL
-    })
+      ttl: CACHE_TTL,
+    });
   }
 
-  return categorySlug
+  return categorySlug;
 }
 
-function categorizeByKeywordsEnhanced(faq: FAQ): { category: string; confidence: number } | null {
-  const text = `${faq.question} ${faq.answer}`.toLowerCase()
-  let bestMatch: { category: string; confidence: number } | null = null
+function categorizeByKeywordsEnhanced(
+  faq: FAQ,
+): { category: string; confidence: number } | null {
+  const text = `${faq.question} ${faq.answer}`.toLowerCase();
+  let bestMatch: { category: string; confidence: number } | null = null;
 
   for (const [categorySlug, keywords] of Object.entries(CATEGORY_KEYWORDS)) {
-    const { primary, secondary, confidence: baseConfidence } = keywords
-    let score = 0
-    let matchDetails: string[] = []
+    const { primary, secondary, confidence: baseConfidence } = keywords;
+    let score = 0;
+    let matchDetails: string[] = [];
 
-    primary.forEach(keyword => {
-      const keywordLower = keyword.toLowerCase()
+    primary.forEach((keyword) => {
+      const keywordLower = keyword.toLowerCase();
       if (text.includes(keywordLower)) {
-        score += 3
-        matchDetails.push(`primary:${keyword}`)
-      } else if (text.includes(keywordLower.substring(0, Math.min(5, keywordLower.length)))) {
-        score += 1
-        matchDetails.push(`partial:${keyword}`)
+        score += 3;
+        matchDetails.push(`primary:${keyword}`);
+      } else if (
+        text.includes(
+          keywordLower.substring(0, Math.min(5, keywordLower.length)),
+        )
+      ) {
+        score += 1;
+        matchDetails.push(`partial:${keyword}`);
       }
-    })
+    });
 
-    secondary.forEach(keyword => {
-      const keywordLower = keyword.toLowerCase()
+    secondary.forEach((keyword) => {
+      const keywordLower = keyword.toLowerCase();
       if (text.includes(keywordLower)) {
-        score += 1
-        matchDetails.push(`secondary:${keyword}`)
+        score += 1;
+        matchDetails.push(`secondary:${keyword}`);
       }
-    })
+    });
 
     if (score > 0) {
-      const maxPossibleScore = (primary.length * 3) + secondary.length
-      const rawConfidence = score / maxPossibleScore
-      const finalConfidence = Math.min(baseConfidence * rawConfidence * 1.2, 1.0)
+      const maxPossibleScore = primary.length * 3 + secondary.length;
+      const rawConfidence = score / maxPossibleScore;
+      const finalConfidence = Math.min(
+        baseConfidence * rawConfidence * 1.2,
+        1.0,
+      );
 
-      console.log(`🔍 Category ${categorySlug}: score=${score}, matches=[${matchDetails.join(', ')}], confidence=${finalConfidence.toFixed(3)}`)
+      console.log(
+        `🔍 Category ${categorySlug}: score=${score}, matches=[${matchDetails.join(", ")}], confidence=${finalConfidence.toFixed(3)}`,
+      );
 
       if (!bestMatch || finalConfidence > bestMatch.confidence) {
-        bestMatch = { category: categorySlug, confidence: finalConfidence }
+        bestMatch = { category: categorySlug, confidence: finalConfidence };
       }
     }
   }
 
-  return bestMatch
+  return bestMatch;
 }
 
-export function analyzeCategorizationQuality(faqs: FAQ[], categories: FAQCategory[]): CategorizationQuality {
-  const stats = analyzeCategorizationStrategy(faqs)
-  const recommendations: string[] = []
+export function analyzeCategorizationQuality(
+  faqs: FAQ[],
+  categories: FAQCategory[],
+): CategorizationQuality {
+  const stats = analyzeCategorizationStrategy(faqs);
+  const recommendations: string[] = [];
 
-  const relationsCoverage = stats.strapiRelations / stats.totalFAQs
-  const categoryCoverage = Object.keys(stats.categoryDistribution).length / categories.length
-  const keywordAccuracy = stats.keywordBased / (stats.keywordBased + stats.uncategorized)
-  const overallEfficiency = (stats.strapiRelations + stats.keywordBased) / stats.totalFAQs
+  const relationsCoverage = stats.strapiRelations / stats.totalFAQs;
+  const categoryCoverage =
+    Object.keys(stats.categoryDistribution).length / categories.length;
+  const keywordAccuracy =
+    stats.keywordBased / (stats.keywordBased + stats.uncategorized);
+  const overallEfficiency =
+    (stats.strapiRelations + stats.keywordBased) / stats.totalFAQs;
 
-  const overallScore = (relationsCoverage * 0.4) + (overallEfficiency * 0.3) + (categoryCoverage * 0.2) + (keywordAccuracy * 0.1)
+  const overallScore =
+    relationsCoverage * 0.4 +
+    overallEfficiency * 0.3 +
+    categoryCoverage * 0.2 +
+    keywordAccuracy * 0.1;
 
   if (relationsCoverage === 0) {
-    recommendations.push('🚨 Critical: No Strapi category relations found - set up FAQ categories in CMS')
-    recommendations.push('📝 Action: Assign FAQs to categories in Strapi admin panel')
-    recommendations.push('⚡ Current: Keyword system provides good fallback coverage')
+    recommendations.push(
+      "🚨 Critical: No Strapi category relations found - set up FAQ categories in CMS",
+    );
+    recommendations.push(
+      "📝 Action: Assign FAQs to categories in Strapi admin panel",
+    );
+    recommendations.push(
+      "⚡ Current: Keyword system provides good fallback coverage",
+    );
   } else if (relationsCoverage < 0.3) {
-    recommendations.push('📈 Improvement: Only partial Strapi relations - complete category assignments')
-    recommendations.push('🔄 Hybrid approach working - gradually transition to API-based')
+    recommendations.push(
+      "📈 Improvement: Only partial Strapi relations - complete category assignments",
+    );
+    recommendations.push(
+      "🔄 Hybrid approach working - gradually transition to API-based",
+    );
   } else if (relationsCoverage < 0.7) {
-    recommendations.push('✨ Good progress: Majority using API relations - finish remaining assignments')
+    recommendations.push(
+      "✨ Good progress: Majority using API relations - finish remaining assignments",
+    );
   }
 
   if (categoryCoverage < 0.8) {
-    const missingCategories = categories.length - Object.keys(stats.categoryDistribution).length
-    recommendations.push(`📁 Content gap: ${missingCategories} categories have no FAQs - review content distribution`)
+    const missingCategories =
+      categories.length - Object.keys(stats.categoryDistribution).length;
+    recommendations.push(
+      `📁 Content gap: ${missingCategories} categories have no FAQs - review content distribution`,
+    );
   }
 
   if (stats.uncategorized > stats.totalFAQs * 0.1) {
-    recommendations.push('🔧 Enhancement: Improve keyword mappings to reduce uncategorized FAQs')
-    recommendations.push('📖 Consider: Add more medical synonyms to CATEGORY_KEYWORDS')
+    recommendations.push(
+      "🔧 Enhancement: Improve keyword mappings to reduce uncategorized FAQs",
+    );
+    recommendations.push(
+      "📖 Consider: Add more medical synonyms to CATEGORY_KEYWORDS",
+    );
   }
 
-  if (stats.apiHealth === 'failed' && stats.keywordBased === 0) {
-    recommendations.push('🆘 Critical: Both API and keyword systems failing - check system health')
+  if (stats.apiHealth === "failed" && stats.keywordBased === 0) {
+    recommendations.push(
+      "🆘 Critical: Both API and keyword systems failing - check system health",
+    );
   }
 
   if (stats.cacheHits / stats.totalFAQs < 0.3) {
-    recommendations.push('⚡ Performance: Consider longer cache TTL for better performance')
+    recommendations.push(
+      "⚡ Performance: Consider longer cache TTL for better performance",
+    );
   }
 
   if (overallScore > 0.8) {
-    recommendations.push('🎉 Excellent: Categorization system performing optimally!')
+    recommendations.push(
+      "🎉 Excellent: Categorization system performing optimally!",
+    );
   } else if (overallScore > 0.6) {
-    recommendations.push('👍 Good: System working well with room for improvement')
+    recommendations.push(
+      "👍 Good: System working well with room for improvement",
+    );
   }
 
   return {
@@ -721,158 +936,208 @@ export function analyzeCategorizationQuality(faqs: FAQ[], categories: FAQCategor
     relationsCoverage,
     keywordAccuracy,
     categoryCoverage,
-    recommendations
-  }
+    recommendations,
+  };
 }
 
 // Utility Functions
-function calculateSearchScore(faq: FAQ, searchTerm: string, matchType: 'question' | 'answer'): number {
-  let score = 0
-  const term = searchTerm.toLowerCase()
+function calculateSearchScore(
+  faq: FAQ,
+  searchTerm: string,
+  matchType: "question" | "answer",
+): number {
+  let score = 0;
+  const term = searchTerm.toLowerCase();
 
-  if (matchType === 'question') {
-    score += 100
+  if (matchType === "question") {
+    score += 100;
   } else {
-    score += 50
+    score += 50;
   }
 
-  const text = (matchType === 'question' ? faq.question : faq.answer).toLowerCase()
+  const text = (
+    matchType === "question" ? faq.question : faq.answer
+  ).toLowerCase();
   if (text.includes(term)) {
-    score += 50
+    score += 50;
   }
 
-  const words = term.split(' ')
-  words.forEach(word => {
+  const words = term.split(" ");
+  words.forEach((word) => {
     if (word.length > 2 && text.includes(word)) {
-      score += 10
+      score += 10;
     }
-  })
+  });
 
-  const priorityBonus = { featured: 30, high: 20, medium: 10, low: 0 }
-  score += priorityBonus[faq.priority]
+  const priorityBonus = { featured: 30, high: 20, medium: 10, low: 0 };
+  score += priorityBonus[faq.priority];
 
-  score += Math.min(faq.helpfulCount * 2, 20)
+  score += Math.min(faq.helpfulCount * 2, 20);
 
-  if (matchType === 'question' && faq.question.length < 100) {
-    score += 10
+  if (matchType === "question" && faq.question.length < 100) {
+    score += 10;
   }
 
-  return score
+  return score;
 }
 
 function highlightText(text: string, searchTerm: string): string {
-  if (!searchTerm || !text) return text
+  if (!searchTerm || !text) return text;
 
-  const words = searchTerm.toLowerCase().split(' ').filter(word => word.length > 2)
-  let highlightedText = text
+  const words = searchTerm
+    .toLowerCase()
+    .split(" ")
+    .filter((word) => word.length > 2);
+  let highlightedText = text;
 
-  words.forEach(word => {
-    const regex = new RegExp(`(${word})`, 'gi')
-    highlightedText = highlightedText.replace(regex, '<mark class="bg-healthcare-accent-green/20 text-healthcare-primary font-medium rounded px-1">$1</mark>')
-  })
+  words.forEach((word) => {
+    const regex = new RegExp(`(${word})`, "gi");
+    highlightedText = highlightedText.replace(
+      regex,
+      '<mark class="bg-healthcare-accent-green/20 text-healthcare-primary font-medium rounded px-1">$1</mark>',
+    );
+  });
 
-  return highlightedText
+  return highlightedText;
 }
 
-function generateSearchSuggestions(searchTerm: string, results: FAQSearchResult[]): string[] {
-  const suggestions: string[] = []
-  const term = searchTerm.toLowerCase()
+function generateSearchSuggestions(
+  searchTerm: string,
+  results: FAQSearchResult[],
+): string[] {
+  const suggestions: string[] = [];
+  const term = searchTerm.toLowerCase();
 
   const medicalSuggestions: { [key: string]: string[] } = {
-    'zweitmeinung': ['zweitmeinung kosten', 'zweitmeinung ablauf', 'zweitmeinung wann sinnvoll'],
-    'operation': ['operation notwendig', 'operation alternativen', 'operation vorbereitung'],
-    'behandlung': ['behandlung ablauf', 'behandlung kosten', 'behandlung dauer'],
-    'diagnose': ['diagnose unsicher', 'diagnose bestätigen', 'diagnose überprüfen'],
-    'therapie': ['therapie alternativen', 'therapie nebenwirkungen', 'therapie erfolg'],
-    'krebs': ['krebs behandlung', 'krebs zweitmeinung', 'krebs therapie'],
-    'herz': ['herz operation', 'herz katheter', 'herz bypass'],
-    'gallenblase': ['gallenblase operation', 'gallenblase steine', 'gallenblase entfernung'],
-    'schilddrüse': ['schilddrüse operation', 'schilddrüse knoten', 'schilddrüse autonomie']
-  }
+    zweitmeinung: [
+      "zweitmeinung kosten",
+      "zweitmeinung ablauf",
+      "zweitmeinung wann sinnvoll",
+    ],
+    operation: [
+      "operation notwendig",
+      "operation alternativen",
+      "operation vorbereitung",
+    ],
+    behandlung: ["behandlung ablauf", "behandlung kosten", "behandlung dauer"],
+    diagnose: [
+      "diagnose unsicher",
+      "diagnose bestätigen",
+      "diagnose überprüfen",
+    ],
+    therapie: [
+      "therapie alternativen",
+      "therapie nebenwirkungen",
+      "therapie erfolg",
+    ],
+    krebs: ["krebs behandlung", "krebs zweitmeinung", "krebs therapie"],
+    herz: ["herz operation", "herz katheter", "herz bypass"],
+    gallenblase: [
+      "gallenblase operation",
+      "gallenblase steine",
+      "gallenblase entfernung",
+    ],
+    schilddrüse: [
+      "schilddrüse operation",
+      "schilddrüse knoten",
+      "schilddrüse autonomie",
+    ],
+  };
 
-  Object.keys(medicalSuggestions).forEach(key => {
+  Object.keys(medicalSuggestions).forEach((key) => {
     if (term.includes(key)) {
-      suggestions.push(...medicalSuggestions[key])
+      suggestions.push(...medicalSuggestions[key]);
     }
-  })
+  });
 
   if (results.length > 0) {
-    const keywords = new Set<string>()
-    results.slice(0, 5).forEach(result => {
-      const words = result.question.toLowerCase().split(' ')
-      words.forEach(word => {
+    const keywords = new Set<string>();
+    results.slice(0, 5).forEach((result) => {
+      const words = result.question.toLowerCase().split(" ");
+      words.forEach((word) => {
         if (word.length > 4 && !term.includes(word)) {
-          keywords.add(word)
+          keywords.add(word);
         }
-      })
-    })
+      });
+    });
 
-    Array.from(keywords).slice(0, 3).forEach(keyword => {
-      suggestions.push(`${term} ${keyword}`)
-    })
+    Array.from(keywords)
+      .slice(0, 3)
+      .forEach((keyword) => {
+        suggestions.push(`${term} ${keyword}`);
+      });
   }
 
-  return suggestions.slice(0, 5)
+  return suggestions.slice(0, 5);
 }
 
-export function groupFAQsByCategory(faqs: FAQ[], categories: FAQCategory[]): Record<string, FAQ[]> {
-  const startTime = Date.now()
-  const grouped: Record<string, FAQ[]> = {}
+export function groupFAQsByCategory(
+  faqs: FAQ[],
+  categories: FAQCategory[],
+): Record<string, FAQ[]> {
+  const startTime = Date.now();
+  const grouped: Record<string, FAQ[]> = {};
 
-  categories.forEach(category => {
-    grouped[category.slug] = []
-  })
+  categories.forEach((category) => {
+    grouped[category.slug] = [];
+  });
 
-  const stats = analyzeCategorizationStrategy(faqs)
-  console.log(`🧠 Using categorization strategy: ${stats.method} (API Health: ${stats.apiHealth})`)
+  const stats = analyzeCategorizationStrategy(faqs);
+  console.log(
+    `🧠 Using categorization strategy: ${stats.method} (API Health: ${stats.apiHealth})`,
+  );
 
-  faqs.forEach(faq => {
-    const categorySlug = intelligentCategorizeFrequentlyAskedQuestion(faq)
+  faqs.forEach((faq) => {
+    const categorySlug = intelligentCategorizeFrequentlyAskedQuestion(faq);
     if (categorySlug && grouped[categorySlug]) {
-      grouped[categorySlug].push(faq)
+      grouped[categorySlug].push(faq);
     }
-  })
+  });
 
-  const processingTime = Date.now() - startTime
+  const processingTime = Date.now() - startTime;
 
-  console.log('📊 FAQ categorization results:')
+  console.log("📊 FAQ categorization results:");
   Object.entries(grouped).forEach(([slug, faqList]) => {
     if (faqList.length > 0) {
-      console.log(`  ✅ ${slug}: ${faqList.length} FAQs`)
+      console.log(`  ✅ ${slug}: ${faqList.length} FAQs`);
     } else {
-      console.log(`  ⚪ ${slug}: 0 FAQs`)
+      console.log(`  ⚪ ${slug}: 0 FAQs`);
     }
-  })
+  });
 
-  console.log(`⚡ Grouping completed in ${processingTime}ms`)
-  console.log(`💾 Cache efficiency: ${stats.cacheHits}/${stats.totalFAQs} entries`)
+  console.log(`⚡ Grouping completed in ${processingTime}ms`);
+  console.log(
+    `💾 Cache efficiency: ${stats.cacheHits}/${stats.totalFAQs} entries`,
+  );
 
-  const quality = analyzeCategorizationQuality(faqs, categories)
-  console.log(`🎯 Categorization Quality Score: ${Math.round(quality.overallScore * 100)}%`)
+  const quality = analyzeCategorizationQuality(faqs, categories);
+  console.log(
+    `🎯 Categorization Quality Score: ${Math.round(quality.overallScore * 100)}%`,
+  );
 
   if (quality.recommendations.length > 0) {
-    console.log('💡 Recommendations:')
-    quality.recommendations.forEach(rec => console.log(`   - ${rec}`))
+    console.log("💡 Recommendations:");
+    quality.recommendations.forEach((rec) => console.log(`   - ${rec}`));
   }
 
-  return grouped
+  return grouped;
 }
 
 export function getFAQCategoryIcon(iconName: string): string {
   const iconMap: Record<string, string> = {
-    'help-circle': 'HelpCircle',
-    'activity': 'Activity',
-    'flask-conical': 'FlaskConical',
-    'heart-pulse': 'HeartPulse',
-    'scan-face': 'ScanFace',
-    'droplet': 'Droplet',
-    'water': 'Droplets'
-  }
+    "help-circle": "HelpCircle",
+    activity: "Activity",
+    "flask-conical": "FlaskConical",
+    "heart-pulse": "HeartPulse",
+    "scan-face": "ScanFace",
+    droplet: "Droplet",
+    water: "Droplets",
+  };
 
-  return iconMap[iconName] || 'HelpCircle'
+  return iconMap[iconName] || "HelpCircle";
 }
 
 // Legacy function for backward compatibility
 export function categorizeFrequentlyAskedQuestion(faq: FAQ): string | null {
-  return intelligentCategorizeFrequentlyAskedQuestion(faq)
+  return intelligentCategorizeFrequentlyAskedQuestion(faq);
 }

--- a/src/types/strapi-real.ts
+++ b/src/types/strapi-real.ts
@@ -2,312 +2,320 @@
 // Based on actual API exploration of zweitmeinu-ng site
 
 export interface StrapiResponse<T> {
-  data: T
+  data: T;
   meta?: {
     pagination?: {
-      page: number
-      pageSize: number
-      pageCount: number
-      total: number
-    }
-  }
+      page: number;
+      pageSize: number;
+      pageCount: number;
+      total: number;
+    };
+  };
 }
 
 // Site Configuration (Real Structure)
 export interface RealSiteConfiguration {
-  id: number
-  documentId: string
-  siteIdentifier: string
-  domain: string
-  siteName: string
-  tagline?: string
-  brand: string
-  specialty?: string
+  id: number;
+  documentId: string;
+  siteIdentifier: string;
+  domain: string;
+  siteName: string;
+  tagline?: string;
+  brand: string;
+  specialty?: string;
   logo?: {
-    id: number
-    documentId: string
-    name: string
-    alternativeText?: string
-    caption?: string
-    width: number
-    height: number
+    id: number;
+    documentId: string;
+    name: string;
+    alternativeText?: string;
+    caption?: string;
+    width: number;
+    height: number;
     formats?: {
       thumbnail?: {
-        url: string
-        width: number
-        height: number
-      }
+        url: string;
+        width: number;
+        height: number;
+      };
       small?: {
-        url: string
-        width: number
-        height: number
-      }
+        url: string;
+        width: number;
+        height: number;
+      };
       medium?: {
-        url: string
-        width: number
-        height: number
-      }
+        url: string;
+        width: number;
+        height: number;
+      };
       large?: {
-        url: string
-        width: number
-        height: number
-      }
-    }
-    url: string
-    mime: string
-    createdAt: string
-    updatedAt: string
-    publishedAt: string
-  }
+        url: string;
+        width: number;
+        height: number;
+      };
+    };
+    url: string;
+    mime: string;
+    createdAt: string;
+    updatedAt: string;
+    publishedAt: string;
+  };
   favicon?: {
-    id: number
-    documentId: string
-    name: string
-    alternativeText?: string
-    caption?: string
-    url: string
-    mime: string
-    createdAt: string
-    updatedAt: string
-    publishedAt: string
-  }
+    id: number;
+    documentId: string;
+    name: string;
+    alternativeText?: string;
+    caption?: string;
+    url: string;
+    mime: string;
+    createdAt: string;
+    updatedAt: string;
+    publishedAt: string;
+  };
   locales?: Array<{
-    code: string
-    name: string
-    isDefault: boolean
-  }>
+    code: string;
+    name: string;
+    isDefault: boolean;
+  }>;
   navigation?: {
     topBar?: {
-      enabled: boolean
+      enabled: boolean;
       content?: Array<{
-        type: string
-        content: string
-        style?: string
-        icon?: string
-      }>
-      backgroundColor?: string
-      textColor?: string
-    }
-    socialMedia?: unknown
+        type: string;
+        content: string;
+        style?: string;
+        icon?: string;
+      }>;
+      backgroundColor?: string;
+      textColor?: string;
+    };
+    socialMedia?: unknown;
     mainNavigation?: Array<{
-      id: string
-      url: string
-      label: string
-      icon?: string
-      type: string
-      order: number
-    }>
+      id: string;
+      url: string;
+      label: string;
+      icon?: string;
+      type: string;
+      order: number;
+    }>;
     ctaButton?: {
-      label?: string
-      url?: string
-      backgroundColor?: string
-      textColor?: string
-      animate?: boolean
-    }
-    mobileMenuSettings?: unknown
-  }
+      label?: string;
+      url?: string;
+      backgroundColor?: string;
+      textColor?: string;
+      animate?: boolean;
+    };
+    mobileMenuSettings?: unknown;
+  };
   footer?: {
     style?: {
       padding?: {
-        top: string
-        bottom: string
-      }
-      columnGap?: string
-      linkColor?: string
-      textColor?: string
-      borderColor?: string
-      linkHoverColor?: string
-      backgroundColor?: string
-    }
+        top: string;
+        bottom: string;
+      };
+      columnGap?: string;
+      linkColor?: string;
+      textColor?: string;
+      borderColor?: string;
+      linkHoverColor?: string;
+      backgroundColor?: string;
+    };
     columns?: Array<{
-      id: string
-      title: string
-      order: number
+      id: string;
+      title: string;
+      order: number;
       links: Array<{
-        url: string
-        label: string
-        type: 'internal' | 'external' | 'action'
-        icon?: string
-        badge?: string
-        badgeColor?: string
-        style?: string
-        openInNewTab?: boolean
-        required?: boolean
-        action?: string
-      }>
-    }>
+        url: string;
+        label: string;
+        type: "internal" | "external" | "action";
+        icon?: string;
+        badge?: string;
+        badgeColor?: string;
+        style?: string;
+        openInNewTab?: boolean;
+        required?: boolean;
+        action?: string;
+      }>;
+    }>;
     copyright?: {
-      text: string
+      text: string;
       additionalLinks?: Array<{
-        url: string
-        label: string
-        type: 'internal' | 'external'
-      }>
-    }
+        url: string;
+        label: string;
+        type: "internal" | "external";
+      }>;
+    };
     newsletter?: {
-      title: string
-      enabled: boolean
-      description: string
-      placeholder: string
-      buttonText: string
-      privacyText: string
+      title: string;
+      enabled: boolean;
+      description: string;
+      placeholder: string;
+      buttonText: string;
+      privacyText: string;
       privacyLink: {
-        url: string
-        text: string
-      }
-      successMessage: string
-      errorMessage: string
-    }
+        url: string;
+        text: string;
+      };
+      successMessage: string;
+      errorMessage: string;
+    };
     socialMedia?: {
-      title: string
-      enabled: boolean
+      title: string;
+      enabled: boolean;
       platforms: Array<{
-        name: string
-        icon: string
-        url: string
-        color: string
-      }>
-    }
+        name: string;
+        icon: string;
+        url: string;
+        color: string;
+      }>;
+    };
     bottomSection?: {
       logo?: {
-        enabled: boolean
-        image: string
-        alt: string
-        link: string
-        width: number
-      }
+        enabled: boolean;
+        image: string;
+        alt: string;
+        link: string;
+        width: number;
+      };
       description?: {
-        enabled: boolean
-        text: string
-      }
+        enabled: boolean;
+        text: string;
+      };
       trustBadges?: {
-        enabled: boolean
-        items: string[]
-      }
+        enabled: boolean;
+        items: string[];
+      };
       certifications?: {
-        enabled: boolean
+        enabled: boolean;
         items: Array<{
-          name: string
-          image: string
-          link?: string | null
-        }>
-      }
-    }
+          name: string;
+          image: string;
+          link?: string | null;
+        }>;
+      };
+    };
     emergencyBanner?: {
-      enabled: boolean
-      text: string
-      buttonText: string
-      phone: string
-      position: string
-      backgroundColor: string
-      textColor: string
-    }
-  }
-  contact?: unknown
-  socialMedia?: unknown
+      enabled: boolean;
+      text: string;
+      buttonText: string;
+      phone: string;
+      position: string;
+      backgroundColor: string;
+      textColor: string;
+    };
+  };
+  contact?: unknown;
+  socialMedia?: unknown;
   openingHours?: {
-    id: number
-    name?: string
+    id: number;
+    name?: string;
     hours?: Array<{
-      day: string
-      openTime?: string
-      closeTime?: string
-      isClosed?: boolean
-    }>
-    emergencyHours?: string
-    notes?: string
-  }
-  createdAt: string
-  updatedAt: string
-  publishedAt: string
+      day: string;
+      openTime?: string;
+      closeTime?: string;
+      isClosed?: boolean;
+    }>;
+    emergencyHours?: string;
+    notes?: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
 }
 
 // Page (Real Structure)
 export interface RealPage {
-  id: number
-  documentId: string
-  title: string
-  slug: string
-  isSharedContent?: boolean
-  sections?: RealDynamicZoneSection[]
-  seo?: unknown
-  createdAt: string
-  updatedAt: string
-  publishedAt: string
+  id: number;
+  documentId: string;
+  title: string;
+  slug: string;
+  isSharedContent?: boolean;
+  sections?: RealDynamicZoneSection[];
+  seo?: unknown;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
 }
 
 // Dynamic Zone Section (Real Structure)
 export interface RealDynamicZoneSection {
-  __component: string
-  id: number
+  __component: string;
+  id: number;
 }
 
 // Hero Carousel (Real Structure)
 export interface RealHeroCarousel extends RealDynamicZoneSection {
-  __component: 'sections.hero-carousel'
-  autoplay: boolean
-  autoplayInterval: number
-  showDots?: boolean
-  showArrows?: boolean
-  transitionType?: string
-  transitionDuration?: number
-  pauseOnHover?: boolean
-  infiniteLoop?: boolean
-  height?: string
-  mobileHeight?: string
-  preloadImages?: boolean
-  lazyLoad?: boolean
-  slides: RealHeroSlide[]
+  __component: "sections.hero-carousel";
+  autoplay: boolean;
+  autoplayInterval: number;
+  showDots?: boolean;
+  showArrows?: boolean;
+  transitionType?: string;
+  transitionDuration?: number;
+  pauseOnHover?: boolean;
+  infiniteLoop?: boolean;
+  height?: string;
+  mobileHeight?: string;
+  preloadImages?: boolean;
+  lazyLoad?: boolean;
+  slides: RealHeroSlide[];
 }
 
 export interface RealHeroSlide {
-  id: number
-  subtitle?: string
-  description?: string | null
-  backgroundGradient?: string
-  customGradient?: string
-  textAlignment?: string
-  overlayOpacity?: number
-  titleLines: RealTitleLine[]
-  backgroundImage?: unknown | null
-  badge?: RealBadge
-  ctaButtons?: RealCTAButton[]
+  id: number;
+  subtitle?: string;
+  description?: string | null;
+  backgroundGradient?: string;
+  customGradient?: string;
+  textAlignment?: string;
+  overlayOpacity?: number;
+  titleLines: RealTitleLine[];
+  backgroundImage?: unknown | null;
+  badge?: RealBadge;
+  ctaButtons?: RealCTAButton[];
 }
 
 export interface RealTitleLine {
-  id: number
-  text: string
-  isHighlighted?: boolean
-  highlightColor?: string
-  fontSize?: string
-  fontWeight?: string
+  id: number;
+  text: string;
+  isHighlighted?: boolean;
+  highlightColor?: string;
+  fontSize?: string;
+  fontWeight?: string;
 }
 
 export interface RealBadge {
-  id: number
-  text: string
-  icon?: string
-  backgroundColor?: string
-  textColor?: string
+  id: number;
+  text: string;
+  icon?: string;
+  backgroundColor?: string;
+  textColor?: string;
 }
 
 export interface RealCTAButton {
-  id: number
-  text: string
-  href: string
-  variant?: string
-  isExternal?: boolean
-  icon?: string
+  id: number;
+  text: string;
+  href: string;
+  variant?: string;
+  isExternal?: boolean;
+  icon?: string;
 }
 
 // Type guards
-export function isRealHeroCarousel(section: RealDynamicZoneSection): section is RealHeroCarousel {
-  return section.__component === 'sections.hero-carousel'
+export function isRealHeroCarousel(
+  section: RealDynamicZoneSection,
+): section is RealHeroCarousel {
+  return section.__component === "sections.hero-carousel";
 }
 
 // Conversion functions to transform real data to expected format
-export function convertRealSiteToExpected(realSite: RealSiteConfiguration): unknown {
-  console.log('🔄 Converting real site config:', realSite)
+export function convertRealSiteToExpected(
+  realSite: RealSiteConfiguration,
+): unknown {
+  console.log("🔄 Converting real site config:", realSite);
+  const STRAPI_ORIGIN = (process.env.NEXT_PUBLIC_STRAPI_URL || "").replace(
+    /\/api$/,
+    "",
+  );
 
   return {
     id: realSite.id,
@@ -318,122 +326,163 @@ export function convertRealSiteToExpected(realSite: RealSiteConfiguration): unkn
       tagline: realSite.tagline,
       brand: realSite.brand,
       specialty: realSite.specialty,
-      logo: realSite.logo ? {
-        data: {
-          attributes: {
-            url: `https://st.zh3.de${realSite.logo.url}`,
-            alternativeText: realSite.logo.alternativeText || realSite.logo.name || `${realSite.siteName} Logo`,
-            width: realSite.logo.width,
-            height: realSite.logo.height,
-            // Use medium format for header if available
-            formats: realSite.logo.formats
+      logo: realSite.logo
+        ? {
+            data: {
+              attributes: {
+                url: `${STRAPI_ORIGIN}${realSite.logo.url}`,
+                alternativeText:
+                  realSite.logo.alternativeText ||
+                  realSite.logo.name ||
+                  `${realSite.siteName} Logo`,
+                width: realSite.logo.width,
+                height: realSite.logo.height,
+                // Use medium format for header if available
+                formats: realSite.logo.formats,
+              },
+            },
           }
-        }
-      } : undefined,
-      favicon: realSite.favicon ? {
-        data: {
-          attributes: {
-            url: `https://st.zh3.de${realSite.favicon.url}`,
-            alternativeText: realSite.favicon.alternativeText || 'Favicon'
+        : undefined,
+      favicon: realSite.favicon
+        ? {
+            data: {
+              attributes: {
+                url: `${STRAPI_ORIGIN}${realSite.favicon.url}`,
+                alternativeText: realSite.favicon.alternativeText || "Favicon",
+              },
+            },
           }
-        }
-      } : undefined,
-      navigation: realSite.navigation ? {
-        main: realSite.navigation.mainNavigation?.map((item: any, index: number) => ({
-          id: parseInt(item.id.replace(/\D/g, '')) || index + 1,
-          label: item.label,
-          href: item.url,
-          isExternal: item.type === 'external',
-          children: item.subItems?.map((subItem: any, subIndex: number) => ({
-            id: subIndex + 1,
-            label: subItem.label,
-            href: subItem.url,
-            isExternal: false
-          })) || undefined
-        })) || [],
-        footer: [] // Legacy footer format - now using the new footer structure
-      } : undefined,
+        : undefined,
+      navigation: realSite.navigation
+        ? {
+            main:
+              realSite.navigation.mainNavigation?.map(
+                (item: any, index: number) => ({
+                  id: parseInt(item.id.replace(/\D/g, "")) || index + 1,
+                  label: item.label,
+                  href: item.url,
+                  isExternal: item.type === "external",
+                  children:
+                    item.subItems?.map((subItem: any, subIndex: number) => ({
+                      id: subIndex + 1,
+                      label: subItem.label,
+                      href: subItem.url,
+                      isExternal: false,
+                    })) || undefined,
+                }),
+              ) || [],
+            footer: [], // Legacy footer format - now using the new footer structure
+          }
+        : undefined,
       contact: {
         id: 1,
-        email: realSite.navigation?.topBar?.content?.find(item => item.type === 'email')?.content || 'kontakt@zweitmeinu.ng',
-        phone: realSite.navigation?.topBar?.content?.find(item => item.type === 'phone')?.content || '+49 800 80 44 100',
-        emergencyHotline: realSite.navigation?.topBar?.content?.find(item => item.type === 'phone')?.content || '+49 800 80 44 100',
-        openingHours: realSite.openingHours ? {
-          regular: realSite.openingHours.hours?.reduce((acc: any, hour: any) => {
-            const dayKey = hour.day.toLowerCase();
-            acc[dayKey] = hour.isClosed ? 'geschlossen' : `${hour.openTime}-${hour.closeTime}`;
-            return acc;
-          }, {}) || {
-            monday: '09:00-16:00',
-            tuesday: '09:00-16:00',
-            wednesday: '09:00-16:00',
-            thursday: '09:00-16:00',
-            friday: '09:00-16:00',
-            saturday: 'geschlossen',
-            sunday: 'geschlossen'
-          },
-          emergency: realSite.openingHours.emergencyHours || '24/7 Notfallberatung'
-        } : {
-          regular: {
-            monday: '09:00-16:00',
-            tuesday: '09:00-16:00',
-            wednesday: '09:00-16:00',
-            thursday: '09:00-16:00',
-            friday: '09:00-16:00',
-            saturday: 'geschlossen',
-            sunday: 'geschlossen'
-          },
-          emergency: '24/7 Notfallberatung'
-        },
-        address: 'Complex Care Solutions GmbH\nBottrop, Deutschland'
+        email:
+          realSite.navigation?.topBar?.content?.find(
+            (item) => item.type === "email",
+          )?.content || "kontakt@zweitmeinu.ng",
+        phone:
+          realSite.navigation?.topBar?.content?.find(
+            (item) => item.type === "phone",
+          )?.content || "+49 800 80 44 100",
+        emergencyHotline:
+          realSite.navigation?.topBar?.content?.find(
+            (item) => item.type === "phone",
+          )?.content || "+49 800 80 44 100",
+        openingHours: realSite.openingHours
+          ? {
+              regular: realSite.openingHours.hours?.reduce(
+                (acc: any, hour: any) => {
+                  const dayKey = hour.day.toLowerCase();
+                  acc[dayKey] = hour.isClosed
+                    ? "geschlossen"
+                    : `${hour.openTime}-${hour.closeTime}`;
+                  return acc;
+                },
+                {},
+              ) || {
+                monday: "09:00-16:00",
+                tuesday: "09:00-16:00",
+                wednesday: "09:00-16:00",
+                thursday: "09:00-16:00",
+                friday: "09:00-16:00",
+                saturday: "geschlossen",
+                sunday: "geschlossen",
+              },
+              emergency:
+                realSite.openingHours.emergencyHours || "24/7 Notfallberatung",
+            }
+          : {
+              regular: {
+                monday: "09:00-16:00",
+                tuesday: "09:00-16:00",
+                wednesday: "09:00-16:00",
+                thursday: "09:00-16:00",
+                friday: "09:00-16:00",
+                saturday: "geschlossen",
+                sunday: "geschlossen",
+              },
+              emergency: "24/7 Notfallberatung",
+            },
+        address: "Complex Care Solutions GmbH\nBottrop, Deutschland",
       },
       socialMedia: realSite.socialMedia,
       // Convert top bar data
-      topBar: realSite.navigation?.topBar ? {
-        enabled: realSite.navigation.topBar.enabled || false,
-        content: realSite.navigation.topBar.content || [],
-        backgroundColor: realSite.navigation.topBar.backgroundColor || '#004166',
-        textColor: realSite.navigation.topBar.textColor || '#ffffff'
-      } : undefined,
+      topBar: realSite.navigation?.topBar
+        ? {
+            enabled: realSite.navigation.topBar.enabled || false,
+            content: realSite.navigation.topBar.content || [],
+            backgroundColor:
+              realSite.navigation.topBar.backgroundColor || "#004166",
+            textColor: realSite.navigation.topBar.textColor || "#ffffff",
+          }
+        : undefined,
       // Convert CTA button data
-      ctaButton: realSite.navigation?.ctaButton ? {
-        label: realSite.navigation.ctaButton.label || 'Notfall-Zweitmeinung',
-        url: realSite.navigation.ctaButton.url || '/notfall',
-        backgroundColor: realSite.navigation.ctaButton.backgroundColor || '#B3AF09',
-        textColor: realSite.navigation.ctaButton.textColor || '#ffffff',
-        animate: realSite.navigation.ctaButton.animate || false
-      } : undefined,
+      ctaButton: realSite.navigation?.ctaButton
+        ? {
+            label:
+              realSite.navigation.ctaButton.label || "Notfall-Zweitmeinung",
+            url: realSite.navigation.ctaButton.url || "/notfall",
+            backgroundColor:
+              realSite.navigation.ctaButton.backgroundColor || "#B3AF09",
+            textColor: realSite.navigation.ctaButton.textColor || "#ffffff",
+            animate: realSite.navigation.ctaButton.animate || false,
+          }
+        : undefined,
       // Convert footer data - NEW!
-      footer: realSite.footer ? {
-        style: realSite.footer.style,
-        columns: realSite.footer.columns?.sort((a, b) => a.order - b.order) || [],
-        copyright: realSite.footer.copyright,
-        newsletter: realSite.footer.newsletter,
-        socialMedia: realSite.footer.socialMedia,
-        bottomSection: realSite.footer.bottomSection,
-        emergencyBanner: realSite.footer.emergencyBanner
-      } : undefined,
+      footer: realSite.footer
+        ? {
+            style: realSite.footer.style,
+            columns:
+              realSite.footer.columns?.sort((a, b) => a.order - b.order) || [],
+            copyright: realSite.footer.copyright,
+            newsletter: realSite.footer.newsletter,
+            socialMedia: realSite.footer.socialMedia,
+            bottomSection: realSite.footer.bottomSection,
+            emergencyBanner: realSite.footer.emergencyBanner,
+          }
+        : undefined,
       createdAt: realSite.createdAt,
       updatedAt: realSite.updatedAt,
-      publishedAt: realSite.publishedAt
-    }
-  }
+      publishedAt: realSite.publishedAt,
+    },
+  };
 }
 
 export function convertRealPageToExpected(realPage: RealPage): unknown {
-  console.log('🔄 Converting real page:', realPage.title)
-  console.log('📦 Real sections:', realPage.sections)
+  console.log("🔄 Converting real page:", realPage.title);
+  console.log("📦 Real sections:", realPage.sections);
 
   // Ensure sections exist and are valid
-  const validSections = (realPage.sections || []).filter(section =>
-    section &&
-    typeof section === 'object' &&
-    section.__component &&
-    typeof section.id === 'number' &&
-    section.id > 0
-  )
+  const validSections = (realPage.sections || []).filter(
+    (section) =>
+      section &&
+      typeof section === "object" &&
+      section.__component &&
+      typeof section.id === "number" &&
+      section.id > 0,
+  );
 
-  console.log('✅ Valid sections after filtering:', validSections.length)
+  console.log("✅ Valid sections after filtering:", validSections.length);
 
   return {
     id: realPage.id,
@@ -444,64 +493,71 @@ export function convertRealPageToExpected(realPage: RealPage): unknown {
       seo: realPage.seo,
       createdAt: realPage.createdAt,
       updatedAt: realPage.updatedAt,
-      publishedAt: realPage.publishedAt
-    }
-  }
+      publishedAt: realPage.publishedAt,
+    },
+  };
 }
 
-export function convertRealHeroSlideToExpected(realSlide: RealHeroSlide): unknown {
-  console.log('🔄 Converting real hero slide:', realSlide.id)
+export function convertRealHeroSlideToExpected(
+  realSlide: RealHeroSlide,
+): unknown {
+  console.log("🔄 Converting real hero slide:", realSlide.id);
 
   return {
     id: realSlide.id,
-    badge: realSlide.badge ? {
-      text: realSlide.badge.text,
-      icon: realSlide.badge.icon
-    } : undefined,
-    titleLines: realSlide.titleLines?.map(line => ({
-      id: line.id,
-      text: line.text,
-      highlight: line.isHighlighted || false,
-      color: line.highlightColor
-    })) || [],
+    badge: realSlide.badge
+      ? {
+          text: realSlide.badge.text,
+          icon: realSlide.badge.icon,
+        }
+      : undefined,
+    titleLines:
+      realSlide.titleLines?.map((line) => ({
+        id: line.id,
+        text: line.text,
+        highlight: line.isHighlighted || false,
+        color: line.highlightColor,
+      })) || [],
     subtitle: realSlide.subtitle,
     description: realSlide.description,
     backgroundImage: realSlide.backgroundImage,
     overlayOpacity: realSlide.overlayOpacity,
-    ctaButtons: realSlide.ctaButtons || []
-  }
+    ctaButtons: realSlide.ctaButtons || [],
+  };
 }
 
 // Helper function to safely validate and convert sections
-export function validateAndConvertSections(sections: unknown[]): RealDynamicZoneSection[] {
+export function validateAndConvertSections(
+  sections: unknown[],
+): RealDynamicZoneSection[] {
   if (!Array.isArray(sections)) {
-    console.warn('⚠️ Sections is not an array:', sections)
-    return []
+    console.warn("⚠️ Sections is not an array:", sections);
+    return [];
   }
 
   return sections
     .filter((section): section is RealDynamicZoneSection => {
-      if (!section || typeof section !== 'object') {
-        console.warn('⚠️ Invalid section (not object):', section)
-        return false
+      if (!section || typeof section !== "object") {
+        console.warn("⚠️ Invalid section (not object):", section);
+        return false;
       }
 
-      const sectionObj = section as Record<string, unknown>
+      const sectionObj = section as Record<string, unknown>;
 
-      if (typeof sectionObj.__component !== 'string') {
-        console.warn('⚠️ Invalid section (__component missing):', section)
-        return false
+      if (typeof sectionObj.__component !== "string") {
+        console.warn("⚠️ Invalid section (__component missing):", section);
+        return false;
       }
 
-      if (typeof sectionObj.id !== 'number' || sectionObj.id <= 0) {
-        console.warn('⚠️ Invalid section (invalid id):', section)
-        return false
+      if (typeof sectionObj.id !== "number" || sectionObj.id <= 0) {
+        console.warn("⚠️ Invalid section (invalid id):", section);
+        return false;
       }
 
-      return true
+      return true;
     })
-    .map(section => {
-      console.log('✅ Valid section:', section.__component, section.id)
-      return section
-    })
+    .map((section) => {
+      console.log("✅ Valid section:", section.__component, section.id);
+      return section;
+    });
 }

--- a/test-categories.js
+++ b/test-categories.js
@@ -1,5 +1,5 @@
 // Test FAQ Category Relations
-const BASE_URL = 'https://st.zh3.de/api'
+const BASE_URL = process.env.STRAPI_API_URL || process.env.NEXT_PUBLIC_STRAPI_URL || ''
 
 async function testFAQCategories() {
   console.log('🔍 Testing FAQ Category Relations...\n')


### PR DESCRIPTION
## Summary
- load Strapi API URL from `.env` instead of hardcoding
- derive image host and asset links from the configured base URL
- document env setup with new `.env.example`

## Testing
- `npm run format`
- `npm run lint` *(fails: Unexpected any, no-html-link-for-pages)*

------
https://chatgpt.com/codex/tasks/task_b_68906050ec188321af80cd0e30b9e17f