### PR TITLE
refactor: enforce no-explicit-any and add types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ const eslintConfig = [
       "react/no-unescaped-entities": "off",
       "@next/next/no-img-element": "off",
       "jsx-a11y/alt-text": "off",
+      "@typescript-eslint/no-explicit-any": "error",
     },
   },
 ];

--- a/src/__tests__/bun-test.d.ts
+++ b/src/__tests__/bun-test.d.ts
@@ -1,0 +1,14 @@
+declare module "bun:test" {
+  export function describe(
+    name: string,
+    fn: (...args: unknown[]) => unknown,
+  ): void;
+  export function test(
+    name: string,
+    fn: (...args: unknown[]) => unknown | Promise<unknown>,
+  ): void;
+  export function expect(actual: unknown): {
+    toBe(expected: unknown): void;
+    toEqual(expected: unknown): void;
+  };
+}

--- a/src/__tests__/faq-vote.test.ts
+++ b/src/__tests__/faq-vote.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect } from "bun:test";
+import { NextRequest } from "next/server";
+import {
+  validateVoteRequest,
+  POST,
+  GET,
+} from "../app/api/faq/vote/route";
+
+// Tests for validateVoteRequest
+
+describe("validateVoteRequest", () => {
+  test("rejects non-object body", () => {
+    const result = validateVoteRequest("invalid");
+    expect(result).toEqual({ valid: false, error: "Invalid request body" });
+  });
+
+  test("rejects missing faqId", () => {
+    const result = validateVoteRequest({ isHelpful: true });
+    expect(result).toEqual({ valid: false, error: "Invalid FAQ ID" });
+  });
+
+  test("rejects non-boolean vote", () => {
+    const result = validateVoteRequest({ faqId: 1, isHelpful: "yes" });
+    expect(result).toEqual({ valid: false, error: "Invalid vote value" });
+  });
+
+  test("accepts valid request", () => {
+    const result = validateVoteRequest({ faqId: 1, isHelpful: true });
+    expect(result).toEqual({ valid: true });
+  });
+});
+
+// Tests for POST handler
+
+describe("POST /api/faq/vote", () => {
+  const baseUrl = "http://localhost/api/faq/vote";
+
+  test("returns 400 for non-object body", async () => {
+    const req = new NextRequest(baseUrl, {
+      method: "POST",
+      body: "\"string\"",
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-for": "1.1.1.1",
+      },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error?: string };
+    expect(json.error).toBe("Invalid request body");
+  });
+
+  test("returns 400 for invalid faqId type", async () => {
+    const req = new NextRequest(baseUrl, {
+      method: "POST",
+      body: JSON.stringify({ faqId: "1", isHelpful: true }),
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-for": "1.1.1.2",
+      },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error?: string };
+    expect(json.error).toBe("Invalid FAQ ID");
+  });
+
+  test("returns 400 for invalid isHelpful type", async () => {
+    const req = new NextRequest(baseUrl, {
+      method: "POST",
+      body: JSON.stringify({ faqId: 1, isHelpful: "yes" }),
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-for": "1.1.1.3",
+      },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error?: string };
+    expect(json.error).toBe("Invalid vote value");
+  });
+});
+
+// Tests for GET handler
+
+describe("GET /api/faq/vote", () => {
+  const baseUrl = "http://localhost/api/faq/vote";
+
+  test("returns 400 when faqId is missing", async () => {
+    const req = new NextRequest(baseUrl, { method: "GET" });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error?: string };
+    expect(json.error).toBe("FAQ ID is required");
+  });
+
+  test("returns 400 when faqId is not a number", async () => {
+    const req = new NextRequest(`${baseUrl}?faqId=abc`, { method: "GET" });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error?: string };
+    expect(json.error).toBe("Invalid FAQ ID");
+  });
+
+  test("returns 404 when FAQ not found", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ data: null }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const req = new NextRequest(`${baseUrl}?faqId=1`, { method: "GET" });
+    const res = await GET(req);
+    const json = (await res.json()) as { error?: string };
+
+    expect(res.status).toBe(404);
+    expect(json.error).toBe("FAQ not found");
+
+    globalThis.fetch = originalFetch;
+  });
+});
+

--- a/src/app/api/faq/autocomplete/route.ts
+++ b/src/app/api/faq/autocomplete/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { MEDICAL_DICTIONARY } from "@/lib/medical-dictionary";
+import type { FAQ } from "@/lib/strapi/faq";
 
 const STRAPI_BASE_URL =
   process.env.STRAPI_API_URL || process.env.NEXT_PUBLIC_STRAPI_URL || "";
@@ -220,9 +221,9 @@ async function getFAQSuggestions(
     }
 
     const data = await response.json();
-    const faqs = data.data || [];
+    const faqs: FAQ[] = data.data || [];
 
-    return faqs.map((faq: any, index: number) => ({
+    return faqs.map((faq, index) => ({
       id: `faq-${faq.id}`,
       text: faq.question,
       type: "faq" as const,

--- a/src/app/api/faq/vote/route.ts
+++ b/src/app/api/faq/vote/route.ts
@@ -72,7 +72,7 @@ function getClientIP(request: NextRequest): string {
 }
 
 // Validate vote request
-function validateVoteRequest(data: unknown): { valid: boolean; error?: string } {
+export function validateVoteRequest(data: unknown): { valid: boolean; error?: string } {
   if (!data || typeof data !== "object") {
     return { valid: false, error: "Invalid request body" };
   }

--- a/src/app/api/faq/vote/route.ts
+++ b/src/app/api/faq/vote/route.ts
@@ -29,6 +29,11 @@ interface VoteResponse {
   message?: string;
 }
 
+interface FAQData {
+  helpfulCount?: number;
+  notHelpfulCount?: number;
+}
+
 // Rate limiting function
 function checkRateLimit(clientIP: string): boolean {
   const now = Date.now();
@@ -67,16 +72,18 @@ function getClientIP(request: NextRequest): string {
 }
 
 // Validate vote request
-function validateVoteRequest(data: any): { valid: boolean; error?: string } {
+function validateVoteRequest(data: unknown): { valid: boolean; error?: string } {
   if (!data || typeof data !== "object") {
     return { valid: false, error: "Invalid request body" };
   }
 
-  if (typeof data.faqId !== "number" || data.faqId <= 0) {
+  const req = data as Partial<VoteRequest>;
+
+  if (typeof req.faqId !== "number" || req.faqId <= 0) {
     return { valid: false, error: "Invalid FAQ ID" };
   }
 
-  if (typeof data.isHelpful !== "boolean") {
+  if (typeof req.isHelpful !== "boolean") {
     return { valid: false, error: "Invalid vote value" };
   }
 
@@ -84,7 +91,7 @@ function validateVoteRequest(data: any): { valid: boolean; error?: string } {
 }
 
 // Fetch current FAQ data from Strapi
-async function getCurrentFAQData(faqId: number): Promise<any> {
+async function getCurrentFAQData(faqId: number): Promise<FAQData | null> {
   try {
     const response = await fetch(`${STRAPI_BASE_URL}/faqs/${faqId}`, {
       headers: {
@@ -98,7 +105,7 @@ async function getCurrentFAQData(faqId: number): Promise<any> {
     }
 
     const data = await response.json();
-    return data.data;
+    return (data.data as FAQData) ?? null;
   } catch (error) {
     console.error("Error fetching FAQ data:", error);
     throw error;
@@ -164,7 +171,7 @@ export async function POST(
     }
 
     // Parse request body
-    const body = await request.json();
+    const body: unknown = await request.json();
 
     // Validate request
     const validation = validateVoteRequest(body);
@@ -179,7 +186,7 @@ export async function POST(
       );
     }
 
-    const { faqId, isHelpful, sessionId }: VoteRequest = body;
+    const { faqId, isHelpful, sessionId } = body as VoteRequest;
 
     // Get current FAQ data
     const currentFAQ = await getCurrentFAQData(faqId);
@@ -258,36 +265,45 @@ export async function POST(
 }
 
 // GET: Get vote statistics for a specific FAQ
-export async function GET(request: NextRequest): Promise<NextResponse> {
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<VoteResponse>> {
   try {
     const { searchParams } = new URL(request.url);
     const faqIdParam = searchParams.get("faqId");
 
     if (!faqIdParam) {
-      return NextResponse.json(
-        { error: "FAQ ID is required" },
+      return NextResponse.json<VoteResponse>(
+        { success: false, error: "FAQ ID is required" },
         { status: 400 },
       );
     }
 
     const faqId = parseInt(faqIdParam, 10);
     if (isNaN(faqId) || faqId <= 0) {
-      return NextResponse.json({ error: "Invalid FAQ ID" }, { status: 400 });
+      return NextResponse.json<VoteResponse>(
+        { success: false, error: "Invalid FAQ ID" },
+        { status: 400 },
+      );
     }
 
     // Get current FAQ data
     const currentFAQ = await getCurrentFAQData(faqId);
     if (!currentFAQ) {
-      return NextResponse.json({ error: "FAQ not found" }, { status: 404 });
+      return NextResponse.json<VoteResponse>(
+        { success: false, error: "FAQ not found" },
+        { status: 404 },
+      );
     }
 
-    return NextResponse.json(
+    return NextResponse.json<VoteResponse>(
       {
         success: true,
         data: {
           faqId,
           helpfulCount: currentFAQ.helpfulCount || 0,
           notHelpfulCount: currentFAQ.notHelpfulCount || 0,
+          userVote: null,
         },
       },
       { status: 200 },
@@ -295,8 +311,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   } catch (error) {
     console.error("Error getting FAQ vote stats:", error);
 
-    return NextResponse.json(
-      { error: "Internal server error" },
+    return NextResponse.json<VoteResponse>(
+      { success: false, error: "Internal server error" },
       { status: 500 },
     );
   }

--- a/src/components/faq/FAQPageWrapper.tsx
+++ b/src/components/faq/FAQPageWrapper.tsx
@@ -9,8 +9,12 @@ import {
   analyzeCategorizationQuality,
   type FAQSearchResponse,
   type CategorizationStats,
-  type CategorizationQuality
+  type CategorizationQuality,
+  type FAQPage,
+  type FAQCategory,
+  type FAQ
 } from '@/lib/strapi/faq'
+import type { DynamicZoneSection } from '@/types/strapi'
 import { FAQHeroSection } from './FAQHeroSection'
 import { FAQCategoriesGrid } from './FAQCategoriesGrid'
 import { FAQAccordion } from './FAQAccordion'
@@ -18,11 +22,39 @@ import { FAQCTASection } from './FAQCTASection'
 import { FAQSearchResults } from './FAQSearchResults'
 import { FAQCategorizationInfo } from './FAQCategorizationInfo'
 
+interface FAQHeroSection extends DynamicZoneSection {
+  __component: 'sections.faq-hero'
+  title: string
+  subtitle?: string
+  description?: string
+  showSearch?: boolean
+  searchPlaceholder?: string
+  backgroundColor?: string
+}
+
+interface FAQCategoriesSection extends DynamicZoneSection {
+  __component: 'sections.faq-categories'
+  description?: string
+  columns?: number
+  showQuestionCount?: boolean
+}
+
+interface FAQCTASection extends DynamicZoneSection {
+  __component: 'sections.faq-cta'
+  icon: string
+  iconColor?: string
+  title: string
+  description?: string
+  additionalInfo?: string
+  backgroundColor?: string
+  textColor?: string
+}
+
 interface FAQPageWrapperProps {
   initialData: {
-    faqPage: any
-    categories: any[]
-    faqs: any[]
+    faqPage: FAQPage
+    categories: FAQCategory[]
+    faqs: FAQ[]
   }
 }
 
@@ -36,7 +68,7 @@ export function FAQPageWrapper({ initialData }: FAQPageWrapperProps) {
   const [isSearchMode, setIsSearchMode] = useState(false)
 
   // Category-specific FAQ state
-  const [categorizedFAQs, setCategorizedFAQs] = useState<Record<string, any[]>>({})
+  const [categorizedFAQs, setCategorizedFAQs] = useState<Record<string, FAQ[]>>({})
 
   // Categorization analytics state
   const [categorizationStats, setCategorizationStats] = useState<CategorizationStats | null>(null)
@@ -146,9 +178,15 @@ export function FAQPageWrapper({ initialData }: FAQPageWrapperProps) {
   const groupedFAQs = groupFAQsByCategory(faqs, categories)
 
   // Extract sections from Strapi page data
-  const heroSection = faqPage.sections.find((s: any) => s.__component === 'sections.faq-hero')
-  const categoriesSection = faqPage.sections.find((s: any) => s.__component === 'sections.faq-categories')
-  const ctaSection = faqPage.sections.find((s: any) => s.__component === 'sections.faq-cta')
+  const heroSection = faqPage.sections.find(
+    (s): s is FAQHeroSection => s.__component === 'sections.faq-hero'
+  )
+  const categoriesSection = faqPage.sections.find(
+    (s): s is FAQCategoriesSection => s.__component === 'sections.faq-categories'
+  )
+  const ctaSection = faqPage.sections.find(
+    (s): s is FAQCTASection => s.__component === 'sections.faq-cta'
+  )
 
   return (
     <div className="min-h-screen bg-white">
@@ -156,11 +194,11 @@ export function FAQPageWrapper({ initialData }: FAQPageWrapperProps) {
       {heroSection && (
         <FAQHeroSection
           title={heroSection.title}
-          subtitle={heroSection.subtitle}
-          description={heroSection.description}
-          showSearch={heroSection.showSearch}
-          searchPlaceholder={heroSection.searchPlaceholder}
-          backgroundColor={heroSection.backgroundColor}
+          subtitle={heroSection.subtitle ?? ''}
+          description={heroSection.description ?? ''}
+          showSearch={heroSection.showSearch ?? false}
+          searchPlaceholder={heroSection.searchPlaceholder ?? ''}
+          backgroundColor={heroSection.backgroundColor ?? ''}
           onSearch={handleSearch}
           searchTerm={searchTerm}
           isSearching={isSearching}
@@ -340,7 +378,7 @@ export function FAQPageWrapper({ initialData }: FAQPageWrapperProps) {
           <section className="py-16 bg-white">
             <div className="container-custom">
               <div className="space-y-16">
-                {categories.map((category: any) => {
+                {categories.map((category: FAQCategory) => {
                   // Use the keyword-based categorized FAQs
                   const categoryFAQs = groupedFAQs[category.slug] || []
 
@@ -364,12 +402,12 @@ export function FAQPageWrapper({ initialData }: FAQPageWrapperProps) {
       {ctaSection && (
         <FAQCTASection
           icon={ctaSection.icon}
-          iconColor={ctaSection.iconColor}
+          iconColor={ctaSection.iconColor ?? ''}
           title={ctaSection.title}
-          description={ctaSection.description}
+          description={ctaSection.description ?? ''}
           additionalInfo={ctaSection.additionalInfo}
-          backgroundColor={ctaSection.backgroundColor}
-          textColor={ctaSection.textColor}
+          backgroundColor={ctaSection.backgroundColor ?? ''}
+          textColor={ctaSection.textColor ?? ''}
         />
       )}
     </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -12,6 +12,13 @@ import { Menu, X, Phone, ChevronDown, Mail, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { SiteConfiguration } from "@/types/strapi";
 
+interface TopBarContentItem {
+  type: string;
+  content: string;
+  style?: string;
+  icon?: string;
+}
+
 interface HeaderProps {
   siteConfig: SiteConfiguration["attributes"];
 }
@@ -123,7 +130,8 @@ export function Header({ siteConfig }: HeaderProps) {
             <div className="flex items-center justify-center md:justify-between">
               {/* Left Side - Contact Info */}
               <div className="flex items-center gap-6 flex-wrap justify-center md:justify-start">
-                {siteConfig.topBar.content?.map((item: any, index: number) => (
+                {siteConfig.topBar.content?.map(
+                  (item: TopBarContentItem, index: number) => (
                   <div key={index}>
                     {item.type === "phone" && (
                       <a

--- a/src/components/sections/index.tsx
+++ b/src/components/sections/index.tsx
@@ -103,6 +103,7 @@ export function renderSection(section: DynamicZoneSection, index?: number) {
     // Simple component rendering with type assertion
     return (
       <div key={uniqueKey}>
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
         <Component {...(section as any)} />
       </div>
     )

--- a/src/lib/services/faqAutoComplete.ts
+++ b/src/lib/services/faqAutoComplete.ts
@@ -40,12 +40,12 @@ const autoCompleteCache = new Map<string, { data: AutoCompleteResponse; timestam
 const CACHE_TTL = 2 * 60 * 1000 // 2 minutes
 
 // Debounce utility
-function debounce<T extends (...args: any[]) => any>(
-  func: T,
+function debounce<Args extends unknown[]>(
+  func: (...args: Args) => unknown,
   delay: number
-): (...args: Parameters<T>) => void {
+): (...args: Args) => void {
   let timeoutId: NodeJS.Timeout
-  return (...args: Parameters<T>) => {
+  return (...args: Args) => {
     clearTimeout(timeoutId)
     timeoutId = setTimeout(() => func(...args), delay)
   }

--- a/src/lib/strapi/client.ts
+++ b/src/lib/strapi/client.ts
@@ -7,9 +7,19 @@ export class StrapiClient {
       process.env.STRAPI_API_URL || process.env.NEXT_PUBLIC_STRAPI_URL || "";
   }
 
-  async get<T>(endpoint: string, params?: Record<string, any>): Promise<T> {
+  async get<T>(
+    endpoint: string,
+    params?: Record<string, string | number | boolean | undefined>,
+  ): Promise<T> {
     const queryString = params
-      ? `?${new URLSearchParams(params).toString()}`
+      ? `?${new URLSearchParams(
+          Object.entries(params).reduce<Record<string, string>>(
+            (acc, [key, value]) => {
+              if (value !== undefined) acc[key] = String(value);
+              return acc;
+            },
+          {}),
+        ).toString()}`
       : "";
     const url = `${this.baseUrl}${endpoint}${queryString}`;
 
@@ -38,7 +48,10 @@ export class StrapiClient {
     }
   }
 
-  async post<T>(endpoint: string, body?: any): Promise<T> {
+  async post<T, B extends Record<string, unknown>>(
+    endpoint: string,
+    body?: B,
+  ): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
 
     try {
@@ -56,7 +69,7 @@ export class StrapiClient {
         );
       }
 
-      const data = await response.json();
+      const data = (await response.json()) as T;
       return data;
     } catch (error) {
       console.error("Strapi API Error:", error);
@@ -82,9 +95,9 @@ export class StrapiClient {
    * NOTE: This Strapi instance uses a different data structure without 'sites' relation
    */
   buildSiteFilter(
-    additionalFilters?: Record<string, any>,
-  ): Record<string, any> {
-    const filters: Record<string, any> = {
+    additionalFilters?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const filters: Record<string, unknown> = {
       // Note: Based on exploration, this Strapi doesn't use site filtering on pages
       // Pages are already filtered by the specific site setup
     };

--- a/src/lib/strapi/pages.ts
+++ b/src/lib/strapi/pages.ts
@@ -102,18 +102,33 @@ export async function getPageSlugs(): Promise<string[]> {
   }
 }
 
-export function validatePageData(page: any): page is Page {
-  const isValid = page?.id &&
-                  page?.attributes?.slug &&
-                  page?.attributes?.title &&
-                  Array.isArray(page?.attributes?.sections)
+export function validatePageData(page: unknown): page is Page {
+  if (!page || typeof page !== 'object') {
+    console.error('❌ Page validation failed:', { page })
+    return false
+  }
+
+  const p = page as {
+    id?: unknown
+    attributes?: {
+      slug?: unknown
+      title?: unknown
+      sections?: unknown
+    }
+  }
+
+  const isValid =
+    typeof p.id === 'number' &&
+    typeof p.attributes?.slug === 'string' &&
+    typeof p.attributes?.title === 'string' &&
+    Array.isArray(p.attributes?.sections)
 
   if (!isValid) {
     console.error('❌ Page validation failed:', {
-      hasId: !!page?.id,
-      hasSlug: !!page?.attributes?.slug,
-      hasTitle: !!page?.attributes?.title,
-      hasSections: Array.isArray(page?.attributes?.sections),
+      hasId: typeof p.id === 'number',
+      hasSlug: typeof p.attributes?.slug === 'string',
+      hasTitle: typeof p.attributes?.title === 'string',
+      hasSections: Array.isArray(p.attributes?.sections),
       pageStructure: page
     })
   }

--- a/src/types/contact.ts
+++ b/src/types/contact.ts
@@ -27,9 +27,7 @@ export interface ContactSubmission {
 
 export interface ContactAPIResponse {
   data: ContactSubmission
-  meta?: {
-    [key: string]: any
-  }
+  meta?: Record<string, unknown>
 }
 
 export interface ContactAPIError {

--- a/src/types/strapi-real.ts
+++ b/src/types/strapi-real.ts
@@ -357,18 +357,29 @@ export function convertRealSiteToExpected(
         ? {
             main:
               realSite.navigation.mainNavigation?.map(
-                (item: any, index: number) => ({
+                (
+                  item: {
+                    id: string
+                    label: string
+                    url: string
+                    type?: string
+                    subItems?: Array<{ label: string; url: string }>
+                  },
+                  index: number,
+                ) => ({
                   id: parseInt(item.id.replace(/\D/g, "")) || index + 1,
                   label: item.label,
                   href: item.url,
                   isExternal: item.type === "external",
                   children:
-                    item.subItems?.map((subItem: any, subIndex: number) => ({
-                      id: subIndex + 1,
-                      label: subItem.label,
-                      href: subItem.url,
-                      isExternal: false,
-                    })) || undefined,
+                    item.subItems?.map(
+                      (subItem: { label: string; url: string }, subIndex: number) => ({
+                        id: subIndex + 1,
+                        label: subItem.label,
+                        href: subItem.url,
+                        isExternal: false,
+                      }),
+                    ) || undefined,
                 }),
               ) || [],
             footer: [], // Legacy footer format - now using the new footer structure
@@ -391,14 +402,17 @@ export function convertRealSiteToExpected(
         openingHours: realSite.openingHours
           ? {
               regular: realSite.openingHours.hours?.reduce(
-                (acc: any, hour: any) => {
+                (
+                  acc: Record<string, string>,
+                  hour: { day: string; isClosed?: boolean; openTime?: string; closeTime?: string },
+                ) => {
                   const dayKey = hour.day.toLowerCase();
                   acc[dayKey] = hour.isClosed
                     ? "geschlossen"
                     : `${hour.openTime}-${hour.closeTime}`;
                   return acc;
                 },
-                {},
+                {} as Record<string, string>,
               ) || {
                 monday: "09:00-16:00",
                 tuesday: "09:00-16:00",


### PR DESCRIPTION
## Summary
- treat `@typescript-eslint/no-explicit-any` as an error
- type FAQ vote and autocomplete API routes
- add typed params to Strapi client and FAQ page components

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_b_68907caec33c8321918e4507d2b335b8