### PR TITLE
refactor: tighten section typings and move FAQ validation

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,9 +22,6 @@ const nextConfig = {
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
   },
-  experimental: {
-    optimizeCss: true,
-  },
   async headers() {
     return [
       {

--- a/src/__tests__/faq-vote.test.ts
+++ b/src/__tests__/faq-vote.test.ts
@@ -1,10 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { NextRequest } from "next/server";
-import {
-  validateVoteRequest,
-  POST,
-  GET,
-} from "../app/api/faq/vote/route";
+import { POST, GET } from "../app/api/faq/vote/route";
+import { validateVoteRequest } from "@/lib/faq/validateVoteRequest";
 
 // Tests for validateVoteRequest
 

--- a/src/app/api/faq/vote/route.ts
+++ b/src/app/api/faq/vote/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { headers } from "next/headers";
+import { validateVoteRequest } from "@/lib/faq/validateVoteRequest";
 
 const STRAPI_BASE_URL =
   process.env.STRAPI_API_URL || process.env.NEXT_PUBLIC_STRAPI_URL || "";
@@ -69,25 +70,6 @@ function getClientIP(request: NextRequest): string {
   const real = request.headers.get("x-real-ip");
   const ip = forwarded?.split(",")[0] || real || "unknown";
   return ip;
-}
-
-// Validate vote request
-export function validateVoteRequest(data: unknown): { valid: boolean; error?: string } {
-  if (!data || typeof data !== "object") {
-    return { valid: false, error: "Invalid request body" };
-  }
-
-  const req = data as Partial<VoteRequest>;
-
-  if (typeof req.faqId !== "number" || req.faqId <= 0) {
-    return { valid: false, error: "Invalid FAQ ID" };
-  }
-
-  if (typeof req.isHelpful !== "boolean") {
-    return { valid: false, error: "Invalid vote value" };
-  }
-
-  return { valid: true };
 }
 
 // Fetch current FAQ data from Strapi

--- a/src/components/sections/index.tsx
+++ b/src/components/sections/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import dynamic from 'next/dynamic'
-import type { DynamicZoneSection } from '@/types/strapi'
+import type { DynamicZoneSection, HeroSection, MedicalSpecialtiesGrid, TextBlock, ServicesGrid, TestimonialsSection, NewsSection, FAQSection, ContactForm, StatsSection, TeamSection, CTASection } from '@/types/strapi'
+import type { RealHeroCarousel } from '@/types/strapi-real'
+import type { SectionComponentType, SectionComponents } from '@/types/sections'
 
 // Loading components for better performance
 const LoadingHero = () => (
@@ -23,43 +25,43 @@ const LoadingSmall = () => (
 
 // Simplified dynamic loading
 export const sectionComponents = {
-  'sections.hero': dynamic(() => import('./HeroSection'), {
+  'sections.hero': dynamic<HeroSection>(() => import('./HeroSection'), {
     loading: LoadingHero
   }),
-  'sections.hero-carousel': dynamic(() => import('./HeroCarousel'), {
+  'sections.hero-carousel': dynamic<RealHeroCarousel>(() => import('./HeroCarousel'), {
     loading: LoadingHero
   }),
-  'sections.medical-specialties-grid': dynamic(() => import('./MedicalSpecialtiesGrid'), {
+  'sections.medical-specialties-grid': dynamic<MedicalSpecialtiesGrid>(() => import('./MedicalSpecialtiesGrid'), {
     loading: LoadingSection
   }),
-  'sections.text-block': dynamic(() => import('./TextBlock'), {
+  'sections.text-block': dynamic<TextBlock>(() => import('./TextBlock'), {
     loading: LoadingSmall
   }),
-  'sections.services-grid': dynamic(() => import('./ServicesGrid'), {
+  'sections.services-grid': dynamic<ServicesGrid>(() => import('./ServicesGrid'), {
     loading: LoadingSection
   }),
-  'sections.testimonials': dynamic(() => import('./Testimonials'), {
+  'sections.testimonials': dynamic<TestimonialsSection>(() => import('./Testimonials'), {
     loading: LoadingSection
   }),
-  'sections.news': dynamic(() => import('./NewsSection'), {
+  'sections.news': dynamic<NewsSection>(() => import('./NewsSection'), {
     loading: LoadingSection
   }),
-  'sections.faq': dynamic(() => import('./FAQSection'), {
+  'sections.faq': dynamic<FAQSection>(() => import('./FAQSection'), {
     loading: LoadingSection
   }),
-  'sections.contact-form': dynamic(() => import('./ContactForm'), {
+  'sections.contact-form': dynamic<ContactForm>(() => import('./ContactForm'), {
     loading: LoadingSection
   }),
-  'sections.stats': dynamic(() => import('./StatsSection'), {
+  'sections.stats': dynamic<StatsSection>(() => import('./StatsSection'), {
     loading: LoadingSection
   }),
-  'sections.team': dynamic(() => import('./TeamSection'), {
+  'sections.team': dynamic<TeamSection>(() => import('./TeamSection'), {
     loading: LoadingSection
   }),
-  'sections.cta': dynamic(() => import('./CTASection'), {
+  'sections.cta': dynamic<CTASection>(() => import('./CTASection'), {
     loading: LoadingSmall
   }),
-}
+} as unknown as SectionComponents
 
 export function renderSection(section: DynamicZoneSection, index?: number) {
   // Validate section data
@@ -68,7 +70,7 @@ export function renderSection(section: DynamicZoneSection, index?: number) {
     return null
   }
 
-  const Component = sectionComponents[section.__component as keyof typeof sectionComponents]
+  const Component = sectionComponents[section.__component as SectionComponentType]
 
   if (!Component) {
     console.warn(`Unknown section component: ${section.__component}`)
@@ -103,8 +105,7 @@ export function renderSection(section: DynamicZoneSection, index?: number) {
     // Simple component rendering with type assertion
     return (
       <div key={uniqueKey}>
-        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-        <Component {...(section as any)} />
+        <Component {...(section as unknown as Record<string, unknown>)} />
       </div>
     )
   } catch (error) {
@@ -177,5 +178,3 @@ export function debugSectionTypes(sections: DynamicZoneSection[]): void {
   }
 }
 
-// Export type definitions for components
-export type SectionComponentType = keyof typeof sectionComponents

--- a/src/lib/faq/validateVoteRequest.ts
+++ b/src/lib/faq/validateVoteRequest.ts
@@ -1,0 +1,23 @@
+interface VoteRequest {
+  faqId: number
+  isHelpful: boolean
+  sessionId?: string
+}
+
+export function validateVoteRequest(data: unknown): { valid: boolean; error?: string } {
+  if (!data || typeof data !== 'object') {
+    return { valid: false, error: 'Invalid request body' }
+  }
+
+  const req = data as Partial<VoteRequest>
+
+  if (typeof req.faqId !== 'number' || req.faqId <= 0) {
+    return { valid: false, error: 'Invalid FAQ ID' }
+  }
+
+  if (typeof req.isHelpful !== 'boolean') {
+    return { valid: false, error: 'Invalid vote value' }
+  }
+
+  return { valid: true }
+}

--- a/src/types/sections.ts
+++ b/src/types/sections.ts
@@ -1,0 +1,17 @@
+import type { ComponentType } from 'react'
+
+export type SectionComponentType =
+  | 'sections.hero'
+  | 'sections.hero-carousel'
+  | 'sections.medical-specialties-grid'
+  | 'sections.text-block'
+  | 'sections.services-grid'
+  | 'sections.testimonials'
+  | 'sections.news'
+  | 'sections.faq'
+  | 'sections.contact-form'
+  | 'sections.stats'
+  | 'sections.team'
+  | 'sections.cta'
+
+export type SectionComponents = Record<SectionComponentType, ComponentType<Record<string, unknown>>>

--- a/src/types/strapi.ts
+++ b/src/types/strapi.ts
@@ -510,6 +510,45 @@ export interface FormField {
   }>
 }
 
+// Stats Section
+export interface StatsSection extends DynamicZoneSection {
+  __component: 'sections.stats'
+  title?: string
+  subtitle?: string
+  stats?: Array<{
+    id: number
+    number: string
+    label: string
+    icon?: string
+  }>
+}
+
+// Team Section
+export interface TeamSection extends DynamicZoneSection {
+  __component: 'sections.team'
+  title?: string
+  subtitle?: string
+  teamMembers?: Array<{
+    id: number
+    name: string
+    position: string
+    bio?: string
+    image?: {
+      data: StrapiMedia
+    }
+  }>
+}
+
+// CTA Section
+export interface CTASection extends DynamicZoneSection {
+  __component: 'sections.cta'
+  title?: string
+  subtitle?: string
+  description?: string
+  ctaButtons?: CTAButton[]
+  backgroundColor?: string
+}
+
 // Utility types for type guards
 export type AnyStrapiSection =
   | HeroSection
@@ -521,3 +560,6 @@ export type AnyStrapiSection =
   | NewsSection
   | FAQSection
   | ContactForm
+  | StatsSection
+  | TeamSection
+  | CTASection


### PR DESCRIPTION
## Summary
- add central section component type map
- remove `any` cast when rendering sections
- extract FAQ vote request validator into shared module and update route and tests
- extend Strapi section typings for stats, team, and CTA
- disable experimental CSS optimization to remove `critters` dependency

## Testing
- `bun run lint`
- `NEXT_PUBLIC_STRAPI_URL=http://localhost/api bun run build`


------
https://chatgpt.com/codex/tasks/task_b_68908b3fbb2c832193fc028220ffa1f4