### PR TITLE
feat: add motivation page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,7 +62,8 @@ export default async function RootLayout({
         { id: 1, label: "Home", href: "/" },
         { id: 2, label: "Zweitmeinung", href: "/zweitmeinung" },
         { id: 3, label: "Fachbereiche", href: "/fachbereiche" },
-        { id: 4, label: "Kontakt", href: "/kontakt" },
+        { id: 4, label: "Motivation", href: "/motivation" },
+        { id: 5, label: "Kontakt", href: "/kontakt" },
       ],
       footer: [
         {

--- a/src/app/motivation/page.tsx
+++ b/src/app/motivation/page.tsx
@@ -1,0 +1,89 @@
+import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
+import { getPageBySlug, getPageMetadata } from '@/lib/strapi/pages'
+import { renderSection, debugSectionTypes } from '@/components/sections'
+import type { Page, DynamicZoneSection } from '@/types/strapi'
+
+type TwitterCardType = 'summary' | 'summary_large_image' | 'app' | 'player'
+
+export async function generateMetadata(): Promise<Metadata> {
+  try {
+    const pageData = await getPageBySlug('motivation')
+
+    if (!pageData) {
+      return {
+        title: 'Motivation',
+        description: 'Warum wir uns für Ihre Gesundheit einsetzen',
+      }
+    }
+
+    const metadata = getPageMetadata(pageData)
+
+    return {
+      title: metadata.title,
+      description: metadata.description,
+      keywords: metadata.keywords,
+      openGraph: {
+        title: metadata.ogTitle,
+        description: metadata.ogDescription,
+        images: metadata.ogImage ? [metadata.ogImage] : undefined,
+      },
+      twitter: {
+        card: metadata.twitterCard as TwitterCardType,
+        title: metadata.ogTitle,
+        description: metadata.ogDescription,
+        images: metadata.ogImage ? [metadata.ogImage] : undefined,
+      },
+      alternates: {
+        canonical: metadata.canonical || '/motivation',
+      },
+      robots: {
+        index: !metadata.noindex,
+        follow: !metadata.nofollow,
+      },
+    }
+  } catch (error) {
+    console.error('💥 Error generating motivation metadata:', error)
+    return {
+      title: 'Motivation',
+      description: 'Warum wir uns für Ihre Gesundheit einsetzen',
+    }
+  }
+}
+
+export default async function MotivationPage() {
+  let pageData: Page | null = null
+
+  try {
+    pageData = await getPageBySlug('motivation')
+  } catch (error) {
+    console.error('💥 Error loading motivation page:', error)
+  }
+
+  if (!pageData) {
+    notFound()
+  }
+
+  if (process.env.NODE_ENV === 'development' && pageData.attributes.sections) {
+    debugSectionTypes(pageData.attributes.sections)
+  }
+
+  const sections: DynamicZoneSection[] =
+    pageData.attributes.sections?.filter((section): section is DynamicZoneSection => {
+      const isValid =
+        section !== null &&
+        typeof section === 'object' &&
+        typeof section.__component === 'string' &&
+        typeof section.id === 'number' &&
+        section.id > 0
+
+      if (!isValid) {
+        console.warn('Skipping invalid section in motivation page:', section)
+      }
+
+      return isValid
+    }) || []
+
+  return <>{sections.map((section, index) => renderSection(section, index))}</>
+}
+

--- a/src/lib/strapi/site-config.ts
+++ b/src/lib/strapi/site-config.ts
@@ -116,8 +116,9 @@ export function getFallbackSiteConfig(): SiteConfiguration {
           { id: 1, label: 'Home', href: '/' },
           { id: 2, label: 'Zweitmeinung', href: '/zweitmeinung' },
           { id: 3, label: 'Fachbereiche', href: '/fachbereiche' },
-          { id: 4, label: 'Über uns', href: '/ueber-uns' },
-          { id: 5, label: 'Kontakt', href: '/kontakt' },
+          { id: 4, label: 'Motivation', href: '/motivation' },
+          { id: 5, label: 'Über uns', href: '/ueber-uns' },
+          { id: 6, label: 'Kontakt', href: '/kontakt' },
         ],
         footer: [
           {


### PR DESCRIPTION
## Summary
- add motivation page that renders Strapi sections and metadata
- include motivation link in fallback navigation config

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890bcbe97c48321baca322f145a4739