### PR TITLE
chore: enable a11y lint checks

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -28,21 +28,21 @@
         "noImgElement": "off"
       },
       "a11y": {
-        "noAutofocus": "off",
-        "noDistractingElements": "off",
-        "noHeaderScope": "off",
-        "noInteractiveElementToNoninteractiveRole": "off",
-        "noLabelWithoutControl": "off",
-        "noNoninteractiveElementToInteractiveRole": "off",
-        "noNoninteractiveTabindex": "off",
-        "noPositiveTabindex": "off",
-        "noRedundantAlt": "off",
-        "noRedundantRoles": "off",
-        "noSvgWithoutTitle": "off",
-        "useAltText": "off",
-        "useKeyWithClickEvents": "off",
-        "useKeyWithMouseEvents": "off",
-        "useButtonType": "off"
+        "noAutofocus": "warn",
+        "noDistractingElements": "warn",
+        "noHeaderScope": "warn",
+        "noInteractiveElementToNoninteractiveRole": "warn",
+        "noLabelWithoutControl": "warn",
+        "noNoninteractiveElementToInteractiveRole": "warn",
+        "noNoninteractiveTabindex": "warn",
+        "noPositiveTabindex": "warn",
+        "noRedundantAlt": "warn",
+        "noRedundantRoles": "warn",
+        "noSvgWithoutTitle": "warn",
+        "useAltText": "warn",
+        "useKeyWithClickEvents": "warn",
+        "useKeyWithMouseEvents": "warn",
+        "useButtonType": "warn"
       }
     }
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,11 +19,10 @@ const eslintConfig = [
     },
     rules: {
       "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
       "react/no-unescaped-entities": "off",
       "@next/next/no-img-element": "off",
       "jsx-a11y/alt-text": "off",
-      "@typescript-eslint/no-explicit-any": "error",
     },
   },
 ];

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   remote_images = ["https://source.unsplash.com/.*", "https://images.unsplash.com/.*", "https://ext.same-assets.com/.*", "https://ugc.same-assets.com/.*"]
 
 [build]
-  command = "bun test src/__tests__ && bun run build"
+  command = "bun run lint && bun test src/__tests__ && bun run build"
   publish = ".next"
 
 [build.environment]

--- a/src/components/admin/FAQVoteAnalytics.tsx
+++ b/src/components/admin/FAQVoteAnalytics.tsx
@@ -249,7 +249,7 @@ export function FAQVoteAnalytics({ faqs, categories, className }: FAQVoteAnalyti
               <option value="all">Alle Zeit</option>
             </select>
 
-            <button
+            <button type="button"
               onClick={handleRefresh}
               disabled={refreshing}
               className="flex items-center gap-2 px-4 py-2 bg-healthcare-primary hover:bg-healthcare-primary-light text-white rounded-lg transition-colors disabled:opacity-50"
@@ -258,7 +258,7 @@ export function FAQVoteAnalytics({ faqs, categories, className }: FAQVoteAnalyti
               Aktualisieren
             </button>
 
-            <button
+            <button type="button"
               onClick={exportData}
               className="flex items-center gap-2 px-4 py-2 border border-gray-200 hover:bg-gray-50 rounded-lg transition-colors"
             >

--- a/src/components/faq/FAQAccordion.tsx
+++ b/src/components/faq/FAQAccordion.tsx
@@ -238,7 +238,7 @@ export function FAQAccordion({ category, faqs }: FAQAccordionProps) {
           return (
             <div key={faq.id} className="bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-md transition-shadow">
               {/* Question */}
-              <button
+              <button type="button"
                 onClick={() => toggleItem(faq.id)}
                 className="w-full flex items-center justify-between p-6 text-left hover:bg-gray-50 transition-colors rounded-xl"
               >
@@ -322,7 +322,7 @@ export function FAQAccordion({ category, faqs }: FAQAccordionProps) {
                         </div>
 
                         <div className="flex items-center gap-2 mb-3">
-                          <button
+                          <button type="button"
                             onClick={() => handleVote(faq.id, true)}
                             disabled={voteLoading[faq.id] || hasUserVoted(faq.id)}
                             className={cn(
@@ -345,7 +345,7 @@ export function FAQAccordion({ category, faqs }: FAQAccordionProps) {
                             <span>Ja ({getDisplayCounts(faq).helpfulCount})</span>
                           </button>
 
-                          <button
+                          <button type="button"
                             onClick={() => handleVote(faq.id, false)}
                             disabled={voteLoading[faq.id] || hasUserVoted(faq.id)}
                             className={cn(
@@ -405,7 +405,7 @@ export function FAQAccordion({ category, faqs }: FAQAccordionProps) {
       {/* Show More Button */}
       {faqs.length >= 8 && (
         <div className="text-center mt-8">
-          <button className="inline-flex items-center gap-2 px-6 py-3 bg-healthcare-primary hover:bg-healthcare-primary-light text-white rounded-lg transition-colors font-medium">
+          <button type="button" className="inline-flex items-center gap-2 px-6 py-3 bg-healthcare-primary hover:bg-healthcare-primary-light text-white rounded-lg transition-colors font-medium">
             Weitere Fragen anzeigen
             <ChevronDown className="w-4 h-4" />
           </button>

--- a/src/components/faq/FAQCategoriesGrid.tsx
+++ b/src/components/faq/FAQCategoriesGrid.tsx
@@ -77,7 +77,7 @@ export function FAQCategoriesGrid({
           const questionCount = groupedFAQs[category.slug]?.length || 0
 
           return (
-            <button
+            <button type="button"
               key={category.id}
               onClick={() => handleCategoryClick(category.slug)}
               className="group bg-white rounded-xl shadow-md hover:shadow-xl transition-all duration-300 p-6 text-left border border-gray-100 hover:border-healthcare-accent-green/20 hover:-translate-y-1"

--- a/src/components/faq/FAQCategorizationInfo.tsx
+++ b/src/components/faq/FAQCategorizationInfo.tsx
@@ -64,7 +64,7 @@ export function FAQCategorizationInfo({
           </div>
         </div>
 
-        <button
+        <button type="button"
           onClick={() => setIsExpanded(!isExpanded)}
           className="flex items-center gap-1 px-3 py-1 bg-white hover:bg-gray-50 border border-gray-200 rounded-lg text-sm transition-colors"
         >

--- a/src/components/faq/FAQHeroSection.tsx
+++ b/src/components/faq/FAQHeroSection.tsx
@@ -423,7 +423,7 @@ export function FAQHeroSection({
                   </h4>
                   <div className="flex flex-wrap gap-2">
                     {popularSearches.map((search, index) => (
-                      <button
+                      <button type="button"
                         key={index}
                         onClick={() => {
                           setLocalSearchTerm(search)

--- a/src/components/faq/FAQPageWrapper.tsx
+++ b/src/components/faq/FAQPageWrapper.tsx
@@ -244,7 +244,7 @@ export function FAQPageWrapper({ initialData }: FAQPageWrapperProps) {
                 {/* Enhanced Categorization Debug Panel - Only in Development */}
                 {process.env.NODE_ENV === 'development' && categorizationStats && categorizationQuality && (
                   <div className="mt-12">
-                    <button
+                    <button type="button"
                       onClick={() => setShowDebugInfo(!showDebugInfo)}
                       className="mb-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
                     >

--- a/src/components/faq/FAQSearchResults.tsx
+++ b/src/components/faq/FAQSearchResults.tsx
@@ -236,7 +236,7 @@ export function FAQSearchResults({
                 <span>
                   {total} {total === 1 ? 'Ergebnis' : 'Ergebnisse'} für "<strong className="text-healthcare-primary">{searchTerm}</strong>"
                 </span>
-                <button
+                <button type="button"
                   onClick={onClearSearch}
                   className="inline-flex items-center gap-1 text-healthcare-accent-green hover:text-healthcare-accent-hover transition-colors"
                 >
@@ -256,7 +256,7 @@ export function FAQSearchResults({
                   <h3 className="font-semibold text-blue-900 mb-2">Verwandte Suchbegriffe:</h3>
                   <div className="flex flex-wrap gap-2">
                     {suggestions.map((suggestion, index) => (
-                      <button
+                      <button type="button"
                         key={index}
                         onClick={() => onSuggestionClick(suggestion)}
                         className="inline-flex items-center gap-1 px-3 py-1 bg-blue-100 hover:bg-blue-200 text-blue-800 rounded-full text-sm transition-colors"
@@ -307,7 +307,7 @@ export function FAQSearchResults({
                 Versuchen Sie es mit anderen Suchbegriffen oder kontaktieren Sie uns direkt.
               </p>
               <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                <button
+                <button type="button"
                   onClick={onClearSearch}
                   className="px-6 py-3 bg-healthcare-primary hover:bg-healthcare-primary-light text-white rounded-lg transition-colors"
                 >
@@ -330,7 +330,7 @@ export function FAQSearchResults({
                 return (
                   <div key={result.id} className="bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-md transition-shadow">
                     {/* Question */}
-                    <button
+                    <button type="button"
                       onClick={() => toggleItem(result.id)}
                       className="w-full flex items-center justify-between p-6 text-left hover:bg-gray-50 transition-colors rounded-xl"
                     >
@@ -441,7 +441,7 @@ export function FAQSearchResults({
                               </div>
 
                               <div className="flex items-center gap-2 mb-3">
-                                <button
+                                <button type="button"
                                   onClick={() => handleVote(result.id, true)}
                                   disabled={voteLoading[result.id] || hasUserVoted(result.id)}
                                   className={cn(
@@ -464,7 +464,7 @@ export function FAQSearchResults({
                                   <span>Ja ({getDisplayCounts(result).helpfulCount})</span>
                                 </button>
 
-                                <button
+                                <button type="button"
                                   onClick={() => handleVote(result.id, false)}
                                   disabled={voteLoading[result.id] || hasUserVoted(result.id)}
                                   className={cn(
@@ -535,7 +535,7 @@ export function FAQSearchResults({
           {/* Load More Button (if there are more results) */}
           {results.length > 0 && total > results.length && (
             <div className="text-center mt-8">
-              <button className="inline-flex items-center gap-2 px-6 py-3 bg-healthcare-primary hover:bg-healthcare-primary-light text-white rounded-lg transition-colors font-medium">
+              <button type="button" className="inline-flex items-center gap-2 px-6 py-3 bg-healthcare-primary hover:bg-healthcare-primary-light text-white rounded-lg transition-colors font-medium">
                 Weitere Ergebnisse laden
                 <ChevronDown className="w-4 h-4" />
               </button>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -256,7 +256,7 @@ export function Footer({ siteConfig }: FooterProps) {
                     {column.links.map((link, linkIndex) => (
                       <li key={linkIndex}>
                         {link.type === "action" ? (
-                          <button
+                          <button type="button"
                             className={cn(
                               "flex items-center gap-2 transition-colors duration-300 hover:translate-x-1 text-left w-full",
                               link.style === "link-primary"

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -335,7 +335,7 @@ export function Header({ siteConfig }: HeaderProps) {
                       onMouseEnter={() => setActiveDropdown(item.id)}
                       onMouseLeave={() => setActiveDropdown(null)}
                     >
-                      <button className="flex items-center gap-1 font-medium transition-colors duration-300 relative group text-white hover:text-healthcare-accent-green">
+                      <button type="button" className="flex items-center gap-1 font-medium transition-colors duration-300 relative group text-white hover:text-healthcare-accent-green">
                         {item.label}
                         <ChevronDown className="w-4 h-4 transition-transform duration-300 group-hover:rotate-180" />
                         <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-healthcare-primary-light transition-all duration-300 group-hover:w-full" />
@@ -393,7 +393,7 @@ export function Header({ siteConfig }: HeaderProps) {
             </div>
 
             {/* Mobile Menu Button */}
-            <button
+            <button type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 setIsMobileMenuOpen(!isMobileMenuOpen);
@@ -419,7 +419,7 @@ export function Header({ siteConfig }: HeaderProps) {
                   <div key={item.id}>
                     {item.children && item.children.length > 0 ? (
                       <div>
-                        <button
+                        <button type="button"
                           onClick={() =>
                             setActiveDropdown(
                               activeDropdown === item.id ? null : item.id,

--- a/src/components/sections/ContactForm.tsx
+++ b/src/components/sections/ContactForm.tsx
@@ -64,7 +64,7 @@ export default function ContactForm({
                 <p className="text-healthcare-text-muted mb-8">
                   {successMessage}
                 </p>
-                <button
+                <button type="button"
                   onClick={() => setSubmitStatus('idle')}
                   className="btn-primary"
                 >

--- a/src/components/sections/FAQSection.tsx
+++ b/src/components/sections/FAQSection.tsx
@@ -44,7 +44,7 @@ export default function FAQSection({
 
             return (
               <div key={faq.id} className="border border-healthcare-border rounded-lg overflow-hidden">
-                <button
+                <button type="button"
                   onClick={() => toggleItem(faq.id)}
                   className="w-full px-6 py-4 text-left bg-healthcare-background hover:bg-healthcare-primary hover:text-white transition-colors duration-300 flex items-center justify-between"
                 >

--- a/src/components/sections/HeroCarousel.tsx
+++ b/src/components/sections/HeroCarousel.tsx
@@ -326,7 +326,7 @@ export default function HeroCarousel({
           {/* Navigation Arrows */}
           {showArrows && (
             <>
-              <button
+              <button type="button"
                 onClick={prevSlide}
                 onMouseEnter={() => pauseOnHover && setIsPaused(true)}
                 onMouseLeave={() => pauseOnHover && setIsPaused(false)}
@@ -336,7 +336,7 @@ export default function HeroCarousel({
                 <ChevronLeft className="w-6 h-6 text-white group-hover:scale-110 transition-transform" />
               </button>
 
-              <button
+              <button type="button"
                 onClick={nextSlide}
                 onMouseEnter={() => pauseOnHover && setIsPaused(true)}
                 onMouseLeave={() => pauseOnHover && setIsPaused(false)}
@@ -349,7 +349,7 @@ export default function HeroCarousel({
           )}
 
           {/* Play/Pause Button */}
-          <button
+          <button type="button"
             onClick={() => setIsPlaying(!isPlaying)}
             className="absolute top-4 right-4 md:top-8 md:right-8 z-30 bg-white/20 backdrop-blur-md p-3 rounded-full hover:bg-white/30 transition-all duration-300 focus:outline-none focus:ring-4 focus:ring-white/50"
             aria-label={isPlaying ? "Autoplay pausieren" : "Autoplay starten"}
@@ -365,7 +365,7 @@ export default function HeroCarousel({
           {showDots && (
             <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-30 flex gap-3">
               {slides.map((_, index) => (
-                <button
+                <button type="button"
                   key={index}
                   onClick={() => goToSlide(index)}
                   onMouseEnter={() => pauseOnHover && setIsPaused(true)}


### PR DESCRIPTION
## Summary
- dedupe `@typescript-eslint/no-explicit-any` rule and set it to warn
- enable Biome accessibility rules and add missing `button` types across components
- run `bun run lint` during Netlify builds

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_b_68912503f8688321bb06904286feeaee