### PR TITLE
feat: add strapi types generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "scripts": {
     "dev": "next dev -H 0.0.0.0 --turbopack",
-    "build": "next build",
+    "build": "npm run ts:generate-types && next build",
     "start": "next start",
     "lint": "bunx tsc --noEmit && next lint",
     "format": "bunx biome format --write",
-    "test": "bun test src/__tests__"
+    "test": "bun test src/__tests__",
+    "ts:generate-types": "strapi typescript:generate --out-dir src/types/generated"
   },
   "dependencies": {
     "beasties": "^0.1.0",


### PR DESCRIPTION
## Summary
- run `strapi typescript:generate` via new `ts:generate-types` script
- run types generation as part of `npm run build`
- add placeholder directory for generated types

## Testing
- `npm test`
- `npm run lint` *(fails: Argument of type 'FormField' is not assignable to parameter of type 'FormFieldConfig')*
- `npm run ts:generate-types` *(fails: strapi: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68913057e560832187e776185af29259