### PR TITLE
Add CI workflow and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bun run lint
+      - run: bun test
+      - run: bun run build

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 > Modern healthcare platform for medical second opinions with intelligent search and expert consultation features.
 
+[![CI](https://github.com/c2s-admin/frontend-zweitmeinu-ng/actions/workflows/ci.yml/badge.svg)](https://github.com/c2s-admin/frontend-zweitmeinu-ng/actions/workflows/ci.yml)
 [![Next.js](https://img.shields.io/badge/Next.js-15.3.2-black?style=flat-square&logo=next.js)](https://nextjs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.5.4-blue?style=flat-square&logo=typescript)](https://www.typescriptlang.org/)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-3.4.10-38B2AC?style=flat-square&logo=tailwind-css)](https://tailwindcss.com/)


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running install, lint, test, build using Bun
- document CI status badge in README

## Testing
- `bun install`
- `bun run lint` *(fails: TS2345, TS2322)*
- `bun test` *(fails: Cannot find module '@testing-library/react')*
- `bun run build` *(fails: strapi command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68913242a584832195bb291d600cba47