### PR TITLE
Add Playwright API integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # testing
 /coverage
+test-results/
 
 # next.js
 /.next/

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@eslint/eslintrc": "^3.3.1",
+        "@playwright/test": "^1.46.1",
         "@types/node": "^20.17.50",
         "@types/react": "^18.3.22",
         "@types/react-dom": "^18.3.7",
@@ -1147,6 +1148,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -5297,6 +5314,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "bunx tsc --noEmit && next lint",
     "format": "bunx biome format --write",
     "test": "bun test src/__tests__",
+    "test:e2e": "playwright test",
     "ts:generate-types": "strapi typescript:generate --out-dir src/types/generated"
   },
   "dependencies": {
@@ -38,6 +39,7 @@
     "eslint-config-next": "15.1.7",
     "ioredis-mock": "^8.9.0",
     "postcss": "^8.5.3",
+    "@playwright/test": "^1.46.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'node tests/dev-with-mock.js',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/tests/contact-api.spec.ts
+++ b/tests/contact-api.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+const payload = {
+  firstName: 'John',
+  lastName: 'Doe',
+  email: 'john@example.com',
+  subject: 'Hello',
+  message: 'Integration test',
+  urgency: 'low',
+  preferredContact: 'email',
+  consent: true,
+};
+
+test('POST /api/contact-messages forwards data to Strapi', async ({ request }) => {
+  const response = await request.post('/api/contact-messages', { data: payload });
+  expect(response.status()).toBe(201);
+  const data = await response.json();
+  expect(data.attributes.firstName).toBe(payload.firstName);
+  expect(data.attributes).toHaveProperty('submittedAt');
+});

--- a/tests/dev-with-mock.js
+++ b/tests/dev-with-mock.js
@@ -1,0 +1,51 @@
+const { spawn } = require('child_process');
+const http = require('http');
+
+// Simple mock Strapi server
+const strapiServer = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/contact-messages') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      const parsed = JSON.parse(body || '{}');
+      const payload = parsed.data || {};
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({ data: { id: 1, attributes: payload } })
+      );
+    });
+  } else {
+    res.statusCode = 404;
+    res.end();
+  }
+});
+
+strapiServer.listen(5050, () => {
+  console.log('Mock Strapi server running on http://localhost:5050');
+});
+
+const dev = spawn('npm', ['run', 'dev'], {
+  env: {
+    ...process.env,
+    STRAPI_API_URL: 'http://localhost:5050',
+    NEXT_PUBLIC_STRAPI_URL: 'http://localhost:5050'
+  },
+  stdio: 'inherit'
+});
+
+const shutdown = () => {
+  strapiServer.close(() => {
+    process.exit();
+  });
+  dev.kill('SIGINT');
+};
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+dev.on('close', (code) => {
+  shutdown();
+  process.exit(code);
+});


### PR DESCRIPTION
## Summary
- add Playwright as dev dependency and `test:e2e` script
- configure Playwright to run Next.js with a mock Strapi backend
- add integration test for `/api/contact-messages`

## Testing
- `npm test`
- `npm run test:e2e`
- `NEXT_PUBLIC_STRAPI_URL=http://localhost npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68913e5b1d94832183249aa5a146e6b1