### PR TITLE
feat: enable alt text lint rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 2025-08-04
+### Added
+- Enable `jsx-a11y/alt-text` ESLint rule to require alt text on images.
 
 ### Updated
 - Sync README tech stack versions with current dependencies.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,7 +23,7 @@ const eslintConfig = [
       "@typescript-eslint/no-explicit-any": "warn",
       "react/no-unescaped-entities": "off",
       "@next/next/no-img-element": "off",
-      "jsx-a11y/alt-text": "off",
+      "jsx-a11y/alt-text": "warn",
     },
   },
 ];


### PR DESCRIPTION
## Summary
- enable `jsx-a11y/alt-text` ESLint rule to require alt attributes on images
- document change in `CHANGELOG.md`

## Testing
- `NEXT_PUBLIC_STRAPI_URL=http://localhost npm run lint`
- `NEXT_PUBLIC_STRAPI_URL=http://localhost npm test`


------
https://chatgpt.com/codex/tasks/task_b_689140d8f2ac8321a0c3023c0c699f87