### PR TITLE
docs: add setup guidance and architecture diagrams

### DIFF
--- a/.env.logging.example
+++ b/.env.logging.example
@@ -1,0 +1,8 @@
+# Logging configuration
+# Supported levels: trace, debug, info, warn, error, fatal
+LOG_LEVEL=info
+# Log output format: json or pretty
+LOG_FORMAT=json
+# Optional file path for file-based logging
+LOG_FILE=app.log
+

--- a/.env.redis.example
+++ b/.env.redis.example
@@ -1,0 +1,8 @@
+# Redis configuration
+REDIS_HOST=localhost
+REDIS_PORT=6379
+# Optional authentication
+REDIS_PASSWORD=
+# Combined URL (takes precedence if set)
+REDIS_URL=redis://localhost:6379
+

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+!.env.redis.example
+!.env.logging.example
 
 # secrets
 .secrets

--- a/README.md
+++ b/README.md
@@ -82,11 +82,25 @@ bun install
 
 ### 3. Environment Setup
 ```bash
-# Copy environment variables
+# Base configuration
 cp .env.example .env.local
+
+# Redis cache
+cp .env.redis.example .env.redis.local
+
+# Logging
+cp .env.logging.example .env.logging.local
 
 # Configure your Strapi API endpoint
 NEXT_PUBLIC_STRAPI_URL=https://your-strapi-instance/api
+
+# Redis connection (override host/port as needed)
+REDIS_URL=redis://localhost:6379
+
+# Logging preferences
+LOG_LEVEL=info
+LOG_FORMAT=json
+
 # hCaptcha configuration (optional)
 NEXT_PUBLIC_HCAPTCHA_SITE_KEY=your-hcaptcha-site-key
 HCAPTCHA_SECRET_KEY=your-hcaptcha-secret
@@ -129,6 +143,12 @@ src/
 ├── types/                  # TypeScript type definitions
 └── hooks/                  # Custom React hooks
 ```
+
+---
+
+## 🧱 Architecture Overview
+
+High-level system diagrams are documented in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) to help new contributors understand the flow between the frontend, backend, cache, and logging services.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,38 @@
+# Architekturübersicht
+
+Diese Dokumentation bietet einen schnellen Überblick über die wichtigsten Bestandteile des Systems und deren Zusammenspiel.
+
+## Systemübersicht
+```mermaid
+graph TD
+    U[User] -->|HTTP| F[Next.js Frontend]
+    F -->|REST| S[Strapi CMS]
+    F -->|Cache| R[(Redis)]
+    F -->|Logs| L[Logging Service]
+    S -->|Cache| R
+    S -->|Logs| L
+```
+
+## Request Flow
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant F as Frontend
+    participant R as Redis
+    participant S as Strapi
+    participant L as Logger
+
+    U->>F: Request page
+    F->>R: Cache lookup
+    R-->>F: Miss
+    F->>S: Fetch content
+    S-->>F: Response
+    F->>R: Store in cache
+    F->>L: Emit log
+    F-->>U: Rendered page
+```
+
+---
+
+*Zuletzt aktualisiert: 2025-08-05*
+


### PR DESCRIPTION
## Summary
- extend environment setup instructions with Redis and logging examples
- provide example env files for cache and logging services
- add architecture diagrams to clarify system flow

## Testing
- `NEXT_PUBLIC_STRAPI_URL=https://example.com bun run lint`
- `NEXT_PUBLIC_STRAPI_URL=https://example.com bun run test`

------
https://chatgpt.com/codex/tasks/task_b_68914e862c4c8321a07a2d4e01610446