### PR TITLE
chore: add security headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,17 @@ const STRAPI_BASE_PATH = STRAPI.pathname
   .replace(/\/api$/, '')
   .replace(/\/$/, '')
 const STRAPI_UPLOADS_SEGMENT = 'uploads'
+const STRAPI_ORIGIN = STRAPI.origin
+
+const ContentSecurityPolicy = `
+  default-src 'self';
+  script-src 'self';
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' data: https:;
+  connect-src 'self' ${STRAPI_ORIGIN};
+  font-src 'self';
+  frame-ancestors 'none';
+`
 
 const nextConfig = {
   images: {
@@ -45,7 +56,11 @@ const nextConfig = {
           },
           {
             key: 'Referrer-Policy',
-            value: 'strict-origin-when-cross-origin',
+            value: 'no-referrer',
+          },
+          {
+            key: 'Content-Security-Policy',
+            value: ContentSecurityPolicy.replace(/\s{2,}/g, ' ').trim(),
           },
         ],
       },


### PR DESCRIPTION
## Summary
- add Content-Security-Policy header with strict defaults
- tighten referrer policy to `no-referrer`

## Testing
- `NEXT_PUBLIC_STRAPI_URL=http://localhost:1337 bun run lint`
- `NEXT_PUBLIC_STRAPI_URL=http://localhost:1337 bun test src/__tests__`


------
https://chatgpt.com/codex/tasks/task_b_68914e7c96c88321a9157163b2977f8d