### PR TITLE
feat: add rate limiting middleware for contact messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,9 @@
 # Ensure your deployment serves uploaded assets from this same origin.
 NEXT_PUBLIC_STRAPI_URL=https://your-strapi-instance/api
 SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
+
+# Rate limiting for contact message API (defaults shown)
+# CONTACT_MESSAGES_RATE_LIMIT_WINDOW: time window in seconds
+# CONTACT_MESSAGES_RATE_LIMIT_MAX: max requests allowed within the window
+CONTACT_MESSAGES_RATE_LIMIT_WINDOW=60
+CONTACT_MESSAGES_RATE_LIMIT_MAX=5

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ NEXT_PUBLIC_STRAPI_URL=https://your-strapi-instance/api
 # hCaptcha configuration (optional)
 NEXT_PUBLIC_HCAPTCHA_SITE_KEY=your-hcaptcha-site-key
 HCAPTCHA_SECRET_KEY=your-hcaptcha-secret
+# Contact message rate limiting (optional)
+CONTACT_MESSAGES_RATE_LIMIT_WINDOW=60
+CONTACT_MESSAGES_RATE_LIMIT_MAX=5
 ```
 
 The frontend builds image and favicon URLs by replacing the `/api` segment of
@@ -167,7 +170,7 @@ POST /api/contact-messages
 ```
 **Features:**
 - hCaptcha verification (when configured)
-- Rate limiting (5 messages/hour)
+- Rate limiting (5 messages/min, configurable via `CONTACT_MESSAGES_RATE_LIMIT_MAX` and `CONTACT_MESSAGES_RATE_LIMIT_WINDOW`)
 
 ---
 

--- a/src/middlewares/rate-limit.ts
+++ b/src/middlewares/rate-limit.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const WINDOW_MS = parseInt(process.env.CONTACT_MESSAGES_RATE_LIMIT_WINDOW ?? "60") * 1000;
+const MAX_REQUESTS = parseInt(process.env.CONTACT_MESSAGES_RATE_LIMIT_MAX ?? "5");
+
+interface RateLimitInfo {
+  count: number;
+  expires: number;
+}
+
+const ipRecords = new Map<string, RateLimitInfo>();
+
+// periodically purge expired records to prevent unbounded memory growth
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, info] of ipRecords) {
+    if (info.expires <= now) {
+      ipRecords.delete(ip);
+    }
+  }
+}, WINDOW_MS).unref?.();
+
+export function getClientIP(request: NextRequest): string {
+  const forwarded = request.headers.get("x-forwarded-for");
+  const real = request.headers.get("x-real-ip");
+  return forwarded?.split(",")[0] || real || "unknown";
+}
+
+function isAllowed(ip: string): boolean {
+  const now = Date.now();
+  const info = ipRecords.get(ip);
+  if (!info || info.expires <= now) {
+    ipRecords.set(ip, { count: 1, expires: now + WINDOW_MS });
+    return true;
+  }
+  if (info.count < MAX_REQUESTS) {
+    info.count += 1;
+    return true;
+  }
+  return false;
+}
+
+type Handler = (request: NextRequest) => Promise<NextResponse>;
+
+export function withRateLimit(handler: Handler): Handler {
+  return async (request: NextRequest) => {
+    const ip = getClientIP(request);
+    if (!isAllowed(ip)) {
+      const info = ipRecords.get(ip);
+      const retryAfter = info ? Math.ceil((info.expires - Date.now()) / 1000) : 0;
+      return NextResponse.json(
+        { error: "Too many requests" },
+        {
+          status: 429,
+          headers: { "Retry-After": retryAfter.toString() },
+        },
+      );
+    }
+    return handler(request);
+  };
+}


### PR DESCRIPTION
## Summary
- add configurable rate limiting middleware with cleanup and Retry-After header
- protect contact messages endpoint with rate limiting
- document rate limit environment variables

## Testing
- `npm test`
- `npx playwright test tests/contact-api.spec.ts`
- `NEXT_PUBLIC_STRAPI_URL=https://example.com npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68914f363ee083219b4c16baf8b6a36d